### PR TITLE
add name param to schedules

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4395,6 +4395,9 @@
         "cron"
       ],
       "properties": {
+        "name": {
+          "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
+        },
         "cron": {
           "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
         },
@@ -4408,6 +4411,9 @@
     },
     "UpdateReportScheduleRequestBody": {
       "properties": {
+        "name": {
+          "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
+        },
         "cron": {
           "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
         },
@@ -4418,6 +4424,11 @@
           "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
         }
       }
+    },
+    "ReportScheduleRequestBodyNameProperty": {
+      "type": "string",
+      "description": "The name of the schedule",
+      "example": "Qui Officia"
     },
     "ReportScheduleRequestBodyTimeoutProperty": {
       "type": "integer",
@@ -5240,9 +5251,6 @@
           "type": "string"
         },
         "default": {
-          "type": "boolean"
-        },
-        "default_for_organization_id": {
           "type": "boolean"
         },
         "database": {
@@ -6811,6 +6819,9 @@
     "ReportsEmbeds": {},
     "ReportSchedule": {
       "properties": {
+        "name": {
+          "type": "string"
+        },
         "token": {
           "type": "string"
         },
@@ -6859,6 +6870,7 @@
       },
       "required": [
         "_links",
+        "name",
         "token",
         "parameters",
         "created_at",

--- a/swagger.json
+++ b/swagger.json
@@ -1,1 +1,7456 @@
-{"swagger":"2.0","info":{"version":"0.0.1","title":"Mode","description":"Mode provides a REST API for many common operations, such as:\n\n* Listing spaces and reports\n* Running reports\n* Downloading query results\n\n## Authentication\n\nFor most Mode API calls, the client must supply an API token and secret for\nHTTP basic authentication.\n\nIf authentication is required for a given resource, unauthenticated requests\nwill result in a `401 Unauthorized` response.\n\n[Create and Manage API Tokens](https://modeanalytics.com/settings/access_tokens)\n","termsOfService":"https://mode.com/tos/","contact":{"name":"Mode API Team","email":"support@modeanalytics.com"},"license":{"name":"MIT"}},"host":"modeanalytics.com","basePath":"/api","schemes":["https"],"consumes":["application/json"],"produces":["application/hal+json"],"security":[{"accessTokenAuth":[]}],"securityDefinitions":{"accessTokenAuth":{"type":"basic"}},"paths":{"/account":{"x-summary":"User","get":{"operationId":"getCurrentUser","summary":"Get authorizing user","description":"Returns a representation of the authorizing `User`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"200":{"description":"`User` response","schema":{"$ref":"#/definitions/Account"}}}}},"/{account}/reports/{report}/queries/{query}/charts":{"x-summary":"Charts","get":{"operationId":"listChartsInQuery","summary":"List Charts for a Query","description":"Returns all `Chart`s for a `Query`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Chart` collection response","schema":{"$ref":"#/definitions/QueryCharts"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"query","in":"path","description":"`Query` token","required":true,"type":"string"}]}},"/{account}/reports/{report}/queries/{query}/charts/{chart}":{"x-summary":"Chart","get":{"operationId":"getChart","summary":"Get a chart","description":"Returns a representation of a single `Chart`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Chart` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Chart` response","schema":{"$ref":"#/definitions/Chart"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"query","in":"path","description":"`Query` token","required":true,"type":"string"},{"name":"chart","in":"path","description":"`Chart` token","required":true,"type":"string"}]}},"/{account}/data_sources/{data_source}/schema_updates":{"x-summary":"DataSources","post":{"operationId":"createDataSourceSchemaUpdate","summary":"Update data source schema","description":"Creates and queues a `schema update` for a `data source`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`DataSource` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`DataSourceSchemaUpdate` response","schema":{"$ref":"#/definitions/DataSourceSchemaUpdate"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"data_source","in":"path","description":"`DataSource` token","required":true,"type":"string"}]}},"/{workspace}/data_sources":{"x-summary":"DataSources","get":{"operationId":"listDataSources","summary":"List data sources","description":"Returns all `DataSource`s owned by a `Workspace`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Workspace` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`DataSource` collection response","schema":{"$ref":"#/definitions/DataSources"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"}]}},"/{workspace}/data_sources/{data_source}":{"x-summary":"Data Source","get":{"operationId":"getDataSource","summary":"Get a data source","description":"Returns a single `DataSource`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`DataSource` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`DataSource` response","schema":{"$ref":"#/definitions/DataSource"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"data_source","in":"path","description":"`DataSource` token","required":true,"type":"string"}]},"patch":{"operationId":"updateDataSource","summary":"Update a data source","description":"Updates a `DataSource`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/UpdateDataSourceRequestBody"}},{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"data_source","in":"path","description":"`DataSource` token","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`DataSource` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`DataSource` response","schema":{"$ref":"#/definitions/DataSource"}}}}},"/{workspace}/data_sources/{data_source}/purge":{"x-summary":"Data Source","post":{"operationId":"purgeForDataSource","summary":"Purge report results","description":"Removes all report results that use a data source","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`DataSource` not found","schema":{"$ref":"#/definitions/NotFound"}},"202":{"description":"Accepted","schema":{}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"data_source","in":"path","description":"`DataSource` token","required":true,"type":"string"}]}},"/{workspace}/definitions":{"x-summary":"Definitions","get":{"operationId":"listDefinitions","summary":"List definitions","description":"Returns a list of `Definition`s","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"No default `Library` found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Definitions` collection response","schema":{"$ref":"#/definitions/Definitions"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"in":"query","name":"filter","description":"Filter `Definition`'s by token. Example: `?filter=by_tokens`","type":"string"},{"in":"query","name":"tokens","description":"Comma separated list of `Definition` tokens","type":"string"}]},"post":{"operationId":"createDefinition","summary":"Create a definition","description":"Creates a `Definition`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`DataSource` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Definition` response","schema":{"$ref":"#/definitions/Definition"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"}]}},"/{workspace}/definitions/{definition}":{"x-summary":"Definition","get":{"operationId":"getDefinition","summary":"Get a definition","description":"Returns a representation of `Definition`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Definition` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Definition` response","schema":{"$ref":"#/definitions/Definition"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"definition","in":"path","description":"`Definition` token","required":true,"type":"string"}]},"patch":{"operationId":"updateDefinition","summary":"Update a definition","description":"Updates a `Definition`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Definition` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Definition` response","schema":{"$ref":"#/definitions/Definition"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"definition","in":"path","description":"`Definition` token","required":true,"type":"string"}]},"delete":{"operationId":"deleteDefinition","summary":"Delete a definition","description":"Deletes a `Definition`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Definition` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Definition` response","schema":{"$ref":"#/definitions/Definition"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"definition","in":"path","description":"`Definition` token","required":true,"type":"string"}]}},"/{workspace}/invites":{"x-summary":"Invite","post":{"operationId":"createOrganizationInvite","summary":"Create an invitation","description":"Creates a `User` and invites `User` to `Workspace`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/CreateInviteRequestBody"}},{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Membership` not found for `Workspace`","schema":{"$ref":"#/definitions/NotFound"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`WorkspaceInvite` response","schema":{"$ref":"#/definitions/Invite"}}}}},"/{workspace}/memberships":{"x-summary":"Workspace Memberships","get":{"operationId":"listMemberships","summary":"List memberships","description":"Returns a list of `Membership`s","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Workspace` not found","schema":{"$ref":"#/definitions/NotFound"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"}]}},"/{workspace}/memberships/{membership}":{"x-summary":"Workspace Membership","get":{"operationId":"getMembership","summary":"Get a membership","description":"Returns a representation of a `Membership`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Membership` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Membership` response","schema":{"$ref":"#/definitions/Membership"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"membership","in":"path","description":"`Membership` token","required":true,"type":"string"}]},"delete":{"operationId":"deleteMembership","summary":"Delete a membership","description":"Deletes a `Membership`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Membership` not found","schema":{"$ref":"#/definitions/NotFound"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`Membership` response","schema":{"$ref":"#/definitions/Membership"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"membership","in":"path","description":"`Membership` token","required":true,"type":"string"}]}},"/{account}/reports/{report}/queries":{"x-summary":"Queries","get":{"operationId":"listQueriesInReport","summary":"List queries","description":"Returns all `Queries` in a `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Query` collection response","schema":{"$ref":"#/definitions/ReportQueries"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}]},"post":{"operationId":"createQueryInReport","summary":"Create a query","description":"Creates a `Query` in a `Report`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/CreateQueryRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Query` response","schema":{"$ref":"#/definitions/Query"}}}}},"/{account}/reports/{report}/queries/{query}":{"x-summary":"Query","get":{"operationId":"getQueryInReport","summary":"Get a query","description":"Returns a `Query` in a `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Query` response","schema":{"$ref":"#/definitions/Query"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"query","in":"path","description":"`Query` token","required":true,"type":"string"}]},"patch":{"operationId":"updateQueryInReport","summary":"Upate a query","description":"Updates a `Query` in a `Report`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/UpdateQueryRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"query","in":"path","description":"`Query` token","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Query` response","schema":{"$ref":"#/definitions/Query"}}}},"delete":{"operationId":"deleteQueryInReport","summary":"Delete a query","description":"Deletes a `Query` in a `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Query` response","schema":{"$ref":"#/definitions/Query"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"query","in":"path","description":"`Query` token","required":true,"type":"string"}]}},"/{account}/reports/{report}/runs/{run}/query_runs":{"x-summary":"Query Runs","get":{"operationId":"listQueryRunsForReportRun","summary":"List query runs","description":"Returns all `QueryRun`s for a single `ReportRun`","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"run","in":"path","description":"`ReportRun` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportRun` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"200":{"description":"`QueryRun` collection response","schema":{"$ref":"#/definitions/QueryRuns"}}}}},"/{account}/reports/{report}/runs/{run}/query_runs/{query_run}":{"x-summary":"Query Runs","get":{"operationId":"getQueryRunForReportRun","summary":"Get a query run","description":"Returns a `QueryRun` for a single `ReportRun`","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"run","in":"path","description":"`ReportRun` token","required":true,"type":"string"},{"name":"query_run","in":"path","description":"`Query Run` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportRun` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"200":{"description":"`Query Run`response","schema":{"$ref":"#/definitions/QueryRun"}}}}},"/{account}/reports/{report}/runs/{run}/query_runs/{query_run}/results/content(.csv, .json)":{"x-summary":"Export","get":{"operationId":"getQueryRunContent","summary":"Get query results","description":"Gets the content of a query run in the requested format (csv or json)","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"run","in":"path","description":"`ReportRun` token","required":true,"type":"string"},{"name":"query_run","in":"path","description":"`Query Run` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportRun` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"200":{"description":"`Query Run` result content in the requested format"}}}},"/{account}/reports/{report}/filters":{"x-summary":"Report Filters","get":{"operationId":"listReportFilters","summary":"List report filters","description":"Returns all `ReportFilter`s for a single `Report`","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}],"responses":{"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`ReportFilter` collection response","schema":{"$ref":"#/definitions/ReportFilters"}}}},"post":{"operationId":"createReportFilter","summary":"Create a report filter","description":"Creates a `ReportFilter`","parameters":[{"name":"body","in":"body","description":"`ReportFilter` attributes","required":true,"schema":{"$ref":"#/definitions/CreateOrUpdateReportFilterRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}],"responses":{"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`ReportFilter` response","schema":{"$ref":"#/definitions/ReportFilter"}}}}},"/{account}/reports/{report}/filters/{filter}":{"x-summary":"Report Filter","get":{"operationId":"getReportFilter","summary":"Get a report filter","description":"Gets a `ReportFilter`","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"filter","in":"path","description":"`ReportFilter` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportFilter` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`ReportFilter` response","schema":{"$ref":"#/definitions/ReportFilter"}}}},"patch":{"operationId":"updateReportFilter","summary":"Update a report filter","description":"Updates a `ReportFilter`","parameters":[{"name":"body","in":"body","description":"`ReportFilter` attributes","required":true,"schema":{"$ref":"#/definitions/CreateOrUpdateReportFilterRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"filter","in":"path","description":"`ReportFilter` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportFilter` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`ReportFilter` response","schema":{"$ref":"#/definitions/ReportFilter"}}}},"delete":{"operationId":"deleteReportFilter","summary":"Delete a report filter","description":"Deletes a `ReportFilter`","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"filter","in":"path","description":"`ReportFilter` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportFilter` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`ReportFilter` response","schema":{"$ref":"#/definitions/ReportFilter"}}}}},"/{account}/reports/{report}/exports/runs/{run}/pdf/download":{"x-summary":"Export","get":{"operationId":"getReportRunExport","summary":"Get PDF of a report run","description":"Gets exported pdf of the report run","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"run","in":"path","description":"`ReportRun` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportRun` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"200":{"description":"The data stream containing the exported pdf file"}}}},"/{account}/spaces/{space}/reports":{"x-summary":"Reports","get":{"operationId":"listReportsInSpace","summary":"List reports for a space","description":"Returns all `Report`s in a `Space`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Report` collection response","schema":{"$ref":"#/definitions/Reports"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"space","in":"path","description":"`Space` token","required":true,"type":"string"},{"name":"filter","in":"query","description":"Returns a filtered list of `Report`s in a `Space` filtered by whether their `created_at` or `updated_at` timestamps are `gt` (greater than) or `lt` (less than) the datetime passed in (ISO8601 format). Example: `?filter=created_at.gt.2019-10-23T06:23:01Z` returns all `Reports` in a space created after that date.","required":false,"type":"string"},{"name":"order","in":"query","description":"With the `order_by` param, returns all `Report`s in a `Space` ordered in `asc` or `desc` order. Example: `?order=asc\u0026order_by=created_at`","required":false,"type":"string"},{"name":"order_by","in":"query","description":"With the `order` param, returns all `Report`s in a `Space` ordered by their `created_at` or `updated_at` timestamps. Example: `?order_by=created_at\u0026order=asc`","required":false,"type":"string"}]}},"/{account}/data_sources/{data_source}/reports":{"x-summary":"Reports","get":{"operationId":"listReportsUsingDataSource","summary":"List reports using a data source","description":"Returns all `Report`s using a `DataSource`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Report` collection response","schema":{"$ref":"#/definitions/Reports"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"data_source","in":"path","description":"`DataSource` token","required":true,"type":"string"},{"name":"filter","in":"query","description":"Returns a filtered list of `Report`s in a `Space` filtered by whether their `created_at` or `updated_at` timestamps are `gt` (greater than) or `lt` (less than) the datetime passed in (ISO8601 format). Example: `?filter=created_at.gt.2019-10-23T06:23:01Z` returns all `Reports` in a space created after that date.","required":false,"type":"string"},{"name":"order","in":"query","description":"With the `order_by` param, returns all `Report`s in a `Space` ordered in `asc` or `desc` order. Example: `?order=asc\u0026order_by=created_at`","required":false,"type":"string"},{"name":"order_by","in":"query","description":"With the `order` param, returns all `Report`s in a `Space` ordered by their `created_at` or `updated_at` timestamps. Example: `?order_by=created_at\u0026order=asc`","required":false,"type":"string"}]}},"/{account}/reports/{report}":{"x-summary":"Report","patch":{"operationId":"updateReport","summary":"Update a report","description":"Updates a single `report` with the provided attributes","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/UpdateReportRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Report` response","schema":{"$ref":"#/definitions/Report"}}}},"get":{"operationId":"getReport","summary":"Get a report","description":"Returns a representation of a single `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Report` response","schema":{"$ref":"#/definitions/Report"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}]},"delete":{"operationId":"deleteReport","summary":"Delete a report","description":"Deletes a single `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"Empty body"}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}]}},"/{account}/reports/{report}/archive":{"x-summary":"Report","patch":{"operationId":"archiveReport","summary":"Archive a report","description":"Archives a single `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Report` response","schema":{"$ref":"#/definitions/Report"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}]}},"/{account}/reports/{report}/unarchive":{"x-summary":"Report","patch":{"operationId":"unarchiveReport","summary":"Unarchive a report","description":"Unarchives a single `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Report` response","schema":{"$ref":"#/definitions/Report"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}]}},"/{account}/reports/purge":{"x-summary":"Report","post":{"operationId":"purgeAllReports","summary":"Purge all report results","description":"Removes all report results for an organization","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`Account` not found","schema":{"$ref":"#/definitions/NotFound"}},"202":{"description":"Accepted","schema":{}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"}]}},"/{account}/reports/{report}/schedules":{"x-summary":"ReportSchedule","get":{"operationId":"listReportSchedules","summary":"List schedules for a report","description":"Returns all `Schedule`s for a `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"Report `Schedule` collection response","schema":{"$ref":"#/definitions/ReportSchedules"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}]},"post":{"operationId":"createReportSchedule","summary":"Create a report schedule","description":"Creates a `Report` `Schedule`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/CreateReportScheduleRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"Report `Schedule` response","schema":{"$ref":"#/definitions/ReportSchedule"}}}}},"/{account}/reports/{report}/schedules/{schedule}":{"x-summary":"ReportSchedule","get":{"operationId":"getReportSchedule","summary":"Get a report schedule","description":"Returns a `Report`'s `Schedule`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`ReportSchedule` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"Report `Schedule` response","schema":{"$ref":"#/definitions/ReportSchedule"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"schedule","in":"path","description":"`Schedule` token","required":true,"type":"string"}]},"patch":{"operationId":"updateReportSchedule","summary":"Update a report schedule","description":"Updates a `Report`'s `Schedule`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/UpdateReportScheduleRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"schedule","in":"path","description":"`Schedule` token","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`ReportSchedule` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"Report `Schedule` response","schema":{"$ref":"#/definitions/ReportSchedule"}}}},"delete":{"operationId":"deleteReportSchedule","summary":"Delete a report schedule","description":"Deletes a `Report`'s `Schedule`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`ReportSchedule` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"Empty body"}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"schedule","in":"path","description":"`Schedule` token","required":true,"type":"string"}]}},"/{account}/reports/{report}/subscriptions":{"x-summary":"Report Subscription","get":{"operationId":"listSubscriptionsForReport","summary":"List subscriptions","description":"Returns all `Subscriptions` for a `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`ReportSubscription` collection response","schema":{"$ref":"#/definitions/ReportSubscriptions"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}]},"post":{"operationId":"createSubscriptionForReport","summary":"Create subscription","description":"Creates and returns a `Subscription` for a `Report`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/CreateorUpdateReportSubscriptionRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`ReportSubscription` response","schema":{"$ref":"#/definitions/ReportSubscription"}}}}},"/{account}/reports/{report}/subscriptions/{subscription}":{"x-summary":"Report Subscription","get":{"operationId":"getSubscriptionForReport","summary":"Get subscription","description":"Returns a `Subscription` for a `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`ReportSubscription` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`ReportSubscription` response","schema":{"$ref":"#/definitions/ReportSubscription"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"subscription","in":"path","description":"`ReportSubscription` token","required":true,"type":"string"}]},"patch":{"operationId":"updateSubscriptionForReport","summary":"Update subscription","description":"Updates and returns a `Subscription` for a `Report`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/CreateorUpdateReportSubscriptionRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"subscription","in":"path","description":"`ReportSubscription` token","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`ReportSubscription` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`ReportSubscription` response","schema":{"$ref":"#/definitions/ReportSubscription"}}}},"delete":{"operationId":"deleteSubscriptionForReport","summary":"Delete subscription","description":"Deletes a `Subscription` for a `Report`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`ReportSubscription` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"Empty body"}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"subscription","in":"path","description":"`ReportSubscription` token","required":true,"type":"string"}]}},"/{account}/reports/{report}/schedules/{schedule}/subscriptions":{"x-summary":"Report Subscriptions","get":{"operationId":"listSubscriptionsForReportSchedule","summary":"List schedule subscriptions","description":"Returns all `subscriptions` for a `Report` `Schedule`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`ReportSchedule` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`ReportSubscription` collection response","schema":{"$ref":"#/definitions/ReportSubscriptions"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"schedule","in":"path","description":"`Schedule` token","required":true,"type":"string"}]}},"/{account}/reports/{report}/runs":{"x-summary":"Report Runs","post":{"operationId":"runReport","summary":"Create a report run","description":"Runs a single `Report` and returns a representation of the resulting `ReportRun`","parameters":[{"name":"parameters","in":"body","description":"Custom parameter attributes","schema":{"$ref":"#/definitions/RunReportRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"}],"responses":{"404":{"description":"`Report` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"202":{"description":"`ReportRun` Accepted","schema":{"$ref":"#/definitions/ReportRun"}}}},"get":{"operationId":"listReportRuns","summary":"List report runs","description":"Returns a list of `ReportRun`s for a `Report`","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"filter","in":"query","description":"Returns a filtered list of `Runs`s for a `Report` filtered by whether their `created_at` or `updated_at` timestamps are `gt` (greater than) or `lt` (less than) the datetime passed in (ISO8601 format). Example: `?filter=updated_at.lt.2019-10-23T06:23:01Z` returns all `Runs` in a space created before that date.","required":false,"type":"string"},{"name":"order","in":"query","description":"With the `order` param, returns all `ReportRun`s for a `Report` ordered by their `created_at` or `updated_at` timestamps","required":false,"type":"string"},{"name":"order_by","in":"query","description":"With the `order_by` param, returns all `ReportRun`s for a `Report` ordered in `asc` or `desc` order","required":false,"type":"string"}],"responses":{"404":{"description":"`ReportRun` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"200":{"description":"`ReportRun` collection response","schema":{"$ref":"#/definitions/ReportRuns"}}}}},"/{account}/reports/{report}/runs/{run}/clone":{"x-summary":"Report Run","post":{"operationId":"cloneReportRun","summary":"Clone a report run","description":"Returns a representation of the cloned `ReportRun`","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"run","in":"path","description":"`ReportRun` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportRun` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`Report` response","schema":{"$ref":"#/definitions/Report"}}}}},"/{account}/reports/{report}/runs/{run}/options":{"x-summary":"Form Fields","get":{"operationId":"listFormFields","summary":"List form fields","description":"Returns a list of Form Fields for a `ReportRun`","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"run","in":"path","description":"`ReportRun` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportRun` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`FormField` collection response","schema":{"$ref":"#/definitions/FormField"}}}}},"/{account}/reports/{report}/runs/{run}":{"x-summary":"Report Run","get":{"operationId":"getReportRun","summary":"Get a report run","description":"Returns a representation of a single `ReportRun`","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"run","in":"path","description":"`ReportRun` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportRun` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"200":{"description":"`ReportRun` response","schema":{"$ref":"#/definitions/ReportRun"}}}}},"/{account}/reports/{report}/runs/{run}/results/content(.csv, .json)":{"x-summary":"Export","get":{"operationId":"getReportRunContent","summary":"Get report results","description":"Gets the content of a report run in the requested format (csv or json)","parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"report","in":"path","description":"`Report` token","required":true,"type":"string"},{"name":"run","in":"path","description":"`ReportRun` token","required":true,"type":"string"}],"responses":{"404":{"description":"`ReportRun` not found","schema":{"$ref":"#/definitions/NotFound"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"200":{"description":"`Report Run` result content in the requested format"}}}},"/{account}/spaces/{space}/memberships":{"x-summary":"Space Memberships","post":{"operationId":"createSpaceMemberships","summary":"Create a space membership","description":"Returns all `Memberships` for a `Space`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/CreateSpaceMembershipRequestBody"}},{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"space","in":"path","description":"`Space` token","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`Space` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`SpaceMembership` response","schema":{"$ref":"#/definitions/SpaceMembership"}}}},"get":{"operationId":"listSpaceMemberships","summary":"List space memberships","description":"Returns all `Memberships` for a `Space`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"404":{"description":"`Space` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`SpaceMembership` collection response","schema":{"$ref":"#/definitions/SpaceMemberships"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"space","in":"path","description":"`Space` token","required":true,"type":"string"}]}},"/{account}/spaces/{space}/memberships/{space_membership}":{"x-summary":"Space Membership","get":{"operationId":"getSpaceMembership","summary":"Get a space membership","description":"Returns a single `Membership` for a `Space`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Space Membership` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`SpaceMembership` response","schema":{"$ref":"#/definitions/SpaceMembership"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"space","in":"path","description":"`Space` token","required":true,"type":"string"},{"name":"space_membership","in":"path","description":"`Space Membership` token","required":true,"type":"string"}]},"delete":{"operationId":"deleteSpaceMembership","summary":"Delete a space membership","description":"Delets a single `Membership` for a `Space`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Space Membership` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`SpaceMembership` response","schema":{"$ref":"#/definitions/SpaceMembership"}}},"parameters":[{"name":"account","in":"path","description":"`Account` (`Workspace` or `User`) username","required":true,"type":"string"},{"name":"space","in":"path","description":"`Space` token","required":true,"type":"string"},{"name":"space_membership","in":"path","description":"`Space Membership` token","required":true,"type":"string"}]}},"/{workspace}/spaces":{"x-summary":"Collection","get":{"operationId":"listCollections","summary":"List Collections","description":"Returns a representation of `Collection`s in a `Workspace` visible to the authenticated `User`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Workspace` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Space` collection response","schema":{"$ref":"#/definitions/Spaces"}}},"parameters":[{"in":"query","name":"filter","description":"Returns a filtered list of `Collection`s. Valid options include `all`. The default returns a list of `Collection`'s that do not include other user's personal collections. Example: `?filter=all` returns all `Collections` including personal collections.","required":false,"type":"string"},{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"}]},"post":{"operationId":"createCollection","summary":"Create a Collection","description":"Creates a `Collection`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/CreateOrUpdateSpaceRequestBody"}},{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Account` not found","schema":{"$ref":"#/definitions/NotFound"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`Space` response","schema":{"$ref":"#/definitions/Space"}}}}},"/{workspace}/spaces/{space}":{"x-summary":"Collection","get":{"operationId":"getCollection","summary":"Get a Collection","description":"Returns a representation of a single `Collection`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Space` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Space` response","schema":{"$ref":"#/definitions/Space"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"space","in":"path","description":"`Space` token","required":true,"type":"string"}]},"delete":{"operationId":"deleteCollection","summary":"Delete a Collection","description":"Deletes a single `Collection`","responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Space` not found","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`Space` response","schema":{"$ref":"#/definitions/Space"}}},"parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"space","in":"path","description":"`Space` token","required":true,"type":"string"}]},"post":{"operationId":"updateCollection","summary":"Update a Collection","description":"Updates a `Collection`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/CreateOrUpdateSpaceRequestBody"}},{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"space","in":"path","description":"`Space` token","required":true,"type":"string"}],"responses":{"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"404":{"description":"`Space` not found","schema":{"$ref":"#/definitions/NotFound"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}},"200":{"description":"`Space` response","schema":{"$ref":"#/definitions/Space"}}}}},"/{workspace}/groups/{group_token}/memberships":{"x-summary":"Group Memberships","get":{"operationId":"listGroupMemberships","summary":"List group memberships","description":"Get all `Memberships` of a `Group`","parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"group_token","in":"path","description":"`UserGroup` token","required":true,"type":"string"}],"responses":{"404":{"description":"`Membership` not found for `Workspace`","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`UserGroupMembership` collection response","schema":{"$ref":"#/definitions/UserGroupMemberships"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}}}},"post":{"operationId":"createGroupMembership","summary":"Create a group membership","description":"Create a `Group` `Membership` for a given `User`","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/CreateUserGroupMembershipRequestBody"}},{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"group_token","in":"path","description":"`UserGroup` token","required":true,"type":"string"}],"responses":{"404":{"description":"`Membership` not found for `Workspace`","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`UserGroupMembership` response","schema":{"$ref":"#/definitions/UserGroupMembership"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}}}}},"/{workspace}/groups/{group_token}/memberships/{membership_token}":{"x-summary":"Group Membership","get":{"operationId":"getGroupMembership","summary":"Get a group membership","description":"Get the `Group` `Membership` of a `User`","parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"group_token","in":"path","description":"`UserGroup` token","required":true,"type":"string"},{"name":"membership_token","in":"path","description":"`UserGroupMembership token","required":true,"type":"string"}],"responses":{"404":{"description":"`Membership` not found for `Workspace`","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`UserGroupMembership` response","schema":{"$ref":"#/definitions/UserGroupMembership"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}}}},"delete":{"operationId":"deleteGroupMembership","summary":"Delete a group membership","description":"Remove a `User` from a `Group` by deleting the `Membership`","parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"group_token","in":"path","description":"`UserGroup` token","required":true,"type":"string"},{"name":"membership_token","in":"path","description":"`UserGroupMembership token","required":true,"type":"string"}],"responses":{"404":{"description":"`Membership` not found for `Workspace`","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`UserGroupMembership` response","schema":{"$ref":"#/definitions/UserGroupMembership"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}}}}},"/{workspace}/groups":{"x-summary":"Groups","get":{"operationId":"listGroups","summary":"List groups","description":"Get all `Group`s for a `Workspace`","parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"}],"responses":{"404":{"description":"`Membership` not found for `Workspace`","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`UserGroup` collection response","schema":{"$ref":"#/definitions/UserGroups"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}}}},"post":{"operationId":"createGroup","summary":"Create a group","description":"Create a user `Group` with the provided attributes","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/CreateUserGroupRequestBody"}},{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"}],"responses":{"404":{"description":"`Membership` not found for `Workspace`","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`UserGroup` response","schema":{"$ref":"#/definitions/UserGroup"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}}}}},"/{workspace}/groups/{group_token}":{"x-summary":"Group","get":{"operationId":"getGroup","summary":"Get a group","description":"Gets a user `Group`","parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"group_token","in":"path","description":"`UserGroup` token","required":true,"type":"string"}],"responses":{"404":{"description":"`Membership` not found for `Workspace`","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`UserGroup` response","schema":{"$ref":"#/definitions/UserGroup"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}}}},"delete":{"operationId":"deleteGroup","summary":"Delete a group","description":"Deletes a user `Group`","parameters":[{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"group_token","in":"path","description":"`UserGroup` token","required":true,"type":"string"}],"responses":{"404":{"description":"`Membership` not found for `Workspace`","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`UserGroup` response","schema":{"$ref":"#/definitions/UserGroup"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}}}},"patch":{"operationId":"updateGroup","summary":"Update a group","description":"Update a user `Group` with the provided attributes","parameters":[{"name":"parameters","in":"body","schema":{"$ref":"#/definitions/UpdateUserGroupRequestBody"}},{"name":"workspace","in":"path","description":"`Workspace` username","required":true,"type":"string"},{"name":"group_token","in":"path","description":"`UserGroup` token","required":true,"type":"string"}],"responses":{"404":{"description":"`Membership` not found for `Workspace`","schema":{"$ref":"#/definitions/NotFound"}},"200":{"description":"`UserGroup` response","schema":{"$ref":"#/definitions/UserGroup"}},"401":{"description":"Unauthorized","schema":{"$ref":"#/definitions/Unauthorized"}},"403":{"description":"Forbidden","schema":{"$ref":"#/definitions/Forbidden"}},"400":{"description":"Bad request","schema":{"$ref":"#/definitions/BadRequest"}}}}}},"definitions":{"Account":{"properties":{"username":{"type":"string"},"name":{"type":"string"},"id":{"type":"integer"},"token":{"type":"string"},"email":{"type":"string"},"dataset_size_limit_mb":{"type":"string"},"query_run_size_limit_mb":{"type":"string"},"email_verified":{"type":"boolean"},"avatar":{"$ref":"#/definitions/Avatar"},"user":{"type":"boolean"},"space_count":{"type":"integer"},"data_source_count":{"type":"integer"},"organizations_count":{"type":"string"},"trial_state":{"enum":["pending","active","expired"],"type":"string"},"membership_type":{"enum":["admin","full"],"type":"string"},"payment_method_confirmed":{"type":"boolean"},"private_definition_count":{"type":"integer"},"private_definition_limit":{"type":"integer"},"authorized_domains":{"type":"array","items":{"type":"string"}},"plan_code":{"enum":["standard","plus","free"],"type":"string"},"admin_data_source_connections_only":{"type":"boolean"},"scim_enabled":{"type":"string"},"created_at":{"type":"string"},"settings":{"type":"string"},"_links":{"$ref":"#/definitions/AccountLinks"},"_embedded":{"$ref":"#/definitions/AccountEmbeds"}},"required":["_links","username","name","id","token","dataset_size_limit_mb","query_run_size_limit_mb","avatar","user","created_at"]},"AccountLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"web":{"$ref":"#/definitions/Link"},"web_settings":{"$ref":"#/definitions/Link"},"web_data_sources_settings":{"$ref":"#/definitions/Link"},"web_settings_slack":{"$ref":"#/definitions/Link"},"web_public_datasource_home":{"$ref":"#/definitions/Link"},"web_spaces":{"$ref":"#/definitions/Link"},"web_groups":{"$ref":"#/definitions/Link"},"web_new_organization":{"$ref":"#/definitions/Link"},"web_membership_events":{"$ref":"#/definitions/Link"},"web_member_sessions":{"$ref":"#/definitions/Link"},"web_settings_themes":{"$ref":"#/definitions/Link"},"web_trial_appointments":{"$ref":"#/definitions/Link"},"data_sources":{"$ref":"#/definitions/Link"},"data_source":{"$ref":"#/definitions/Link"},"admins":{"$ref":"#/definitions/Link"},"memberships":{"$ref":"#/definitions/Link"},"all_memberships":{"$ref":"#/definitions/Link"},"home_web":{"$ref":"#/definitions/Link"},"home_starred_web":{"$ref":"#/definitions/Link"},"home_explorations_web":{"$ref":"#/definitions/Link"},"home_reports_web":{"$ref":"#/definitions/Link"},"home_search_web":{"$ref":"#/definitions/Link"},"home_discover_web":{"$ref":"#/definitions/Link"},"select_data_sources_web":{"$ref":"#/definitions/Link"},"data_source_connection_request_web":{"$ref":"#/definitions/Link"},"new_invite_web":{"$ref":"#/definitions/Link"},"new_upload_web":{"$ref":"#/definitions/Link"},"billing_web":{"$ref":"#/definitions/Link"},"public_data_sources":{"$ref":"#/definitions/Link"},"organizations":{"$ref":"#/definitions/Link"},"preference":{"$ref":"#/definitions/Link"},"table":{"$ref":"#/definitions/Link"},"report":{"$ref":"#/definitions/Link"},"reports":{"$ref":"#/definitions/Link"},"archived_reports":{"$ref":"#/definitions/Link"},"public_reports":{"$ref":"#/definitions/Link"},"drafts_reports":{"$ref":"#/definitions/Link"},"starred_reports":{"$ref":"#/definitions/Link"},"by_ids_reports":{"$ref":"#/definitions/Link"},"viewed_reports":{"$ref":"#/definitions/Link"},"starred_datasets":{"$ref":"#/definitions/Link"},"by_ids_datasets":{"$ref":"#/definitions/Link"},"viewed_datasets":{"$ref":"#/definitions/Link"},"starred_base_reports":{"$ref":"#/definitions/Link"},"by_ids_base_reports":{"$ref":"#/definitions/Link"},"viewed_base_reports":{"$ref":"#/definitions/Link"},"by_tokens_definitions":{"$ref":"#/definitions/Link"},"bridges":{"$ref":"#/definitions/Link"},"access_tokens":{"$ref":"#/definitions/Link"},"new_report":{"$ref":"#/definitions/Link"},"new_report_web":{"$ref":"#/definitions/Link"},"validate_table":{"$ref":"#/definitions/Link"},"report_views":{"$ref":"#/definitions/Link"},"groups":{"$ref":"#/definitions/Link"},"group":{"$ref":"#/definitions/Link"},"everyone_group":{"$ref":"#/definitions/Link"},"users_groups_with_data_source_entitlements":{"$ref":"#/definitions/Link"},"spaces":{"$ref":"#/definitions/Link"},"space":{"$ref":"#/definitions/Link"},"custom_spaces":{"$ref":"#/definitions/Link"},"move_to_spaces":{"$ref":"#/definitions/Link"},"definitions":{"$ref":"#/definitions/Link"},"definition":{"$ref":"#/definitions/Link"},"color_palettes":{"$ref":"#/definitions/Link"},"all_color_palettes":{"$ref":"#/definitions/Link"},"color_palette":{"$ref":"#/definitions/Link"},"web_color_palettes_settings":{"$ref":"#/definitions/Link"},"validate_space_name":{"$ref":"#/definitions/Link"},"validate_definition_name":{"$ref":"#/definitions/Link"},"slack_app":{"$ref":"#/definitions/Link"},"default_categorical_palette":{"$ref":"#/definitions/Link"},"default_sequential_palette":{"$ref":"#/definitions/Link"},"default_divergent_palette":{"$ref":"#/definitions/Link"},"trial_appointment":{"$ref":"#/definitions/Link"},"member_session_timeout":{"$ref":"#/definitions/Link"},"easy_identity_providers":{"$ref":"#/definitions/Link"},"saml_identity_providers":{"$ref":"#/definitions/Link"},"scim_token":{"$ref":"#/definitions/Link"},"memberships_lite":{"$ref":"#/definitions/Link"}},"required":["self","web","web_public_datasource_home","web_groups","web_new_organization","home_web","home_starred_web","home_explorations_web","home_search_web","new_invite_web","new_upload_web","report","reports","archived_reports","public_reports","drafts_reports","starred_reports","by_ids_reports","viewed_reports","all_color_palettes"]},"AccountEmbeds":{"properties":{"data_sources":{"$ref":"#/definitions/DataSources"},"spaces":{"$ref":"#/definitions/Spaces"},"all_spaces":{"$ref":"#/definitions/Spaces"}}},"RunReportRequestBody":{"required":["parameters"],"type":"object","properties":{"parameters":{"description":"A object of key/value pairs corresponding to custom report parameter names and values","type":"object","example":{"user_id":123,"location":"San Francisco"}}}},"QueriesAttributes":{"required":["data_source_id","create_query_run"],"properties":{"name":{"type":"string","description":"Name of the `Query`"},"data_source_id":{"type":"integer","description":"Numeric ID of the `DataSource` which this `Query` should be associated with"},"create_query_run":{"type":"boolean","description":"Determines whether to include this `Query` when running the `Report`"},"limit":{"type":"boolean","description":"Determines whether a limit of 100 will be automatically applied to the `Query`","default":false},"token":{"type":"string","description":"Identifying token of the `Query`, if it has already been created"},"raw_query":{"type":"string","description":"SQL to run"}}},"CreateInviteRequestBody":{"required":["invite"],"type":"object","properties":{"invite":{"required":["invitee","message"],"type":"object","properties":{"invitee":{"required":["email"],"type":"object","properties":{"email":{"type":"string","example":"harold.ceramicist@example.com"}}},"message":{"type":"string","example":"You are an analyst, Harry!"}}}}},"CreateQueryRequestBody":{"required":["query"],"type":"object","properties":{"query":{"required":["raw_query","data_source_id"],"type":"object","description":"The parameters for the new `query`","properties":{"data_source_id":{"type":"integer","minimum":1,"description":"The id of the data source to use"},"raw_query":{"type":"string","example":"SELECT * from the_way_down","description":"The raw query to be executed"},"name":{"type":"string","example":"Turtles","description":"The name of the new `query`"}}}}},"UpdateQueryRequestBody":{"required":["query"],"type":"object","properties":{"query":{"type":"object","description":"The updated parameters for the `query`","properties":{"data_source_id":{"type":"integer","minimum":1,"description":"The id of the data source to use"},"raw_query":{"type":"string","example":"SELECT * FROM small_table;","description":"The raw query to be executed"},"name":{"type":"string","example":"All the small things","description":"The name of the new `query`"}}}}},"UpdateReportRequestBody":{"required":["report"],"type":"object","properties":{"report":{"type":"object","properties":{"name":{"type":"string","description":"The name of the report","example":"Kanto Region Diaspora"},"description":{"type":"string","description":"A description of the report in question","example":"An analysis of all the creatures living in the region. Please contribute any missing data. Pocket version coming soon."},"space_token":{"type":"string","description":"The token of the space this report will be moved to","example":"5a4177a2902c"}}}}},"CreateOrUpdateReportFilterRequestBody":{"required":["report_filter"],"properties":{"report_filter":{"$ref":"#/definitions/CreateOrUpdateReportFilterAttributes"}}},"CreateOrUpdateReportFilterAttributes":{"required":["name","formula","data_type","formula_type","variable_type","filter_type","control_type","options"],"properties":{"name":{"type":"string","description":"`ReportFilter` name"},"formula":{"type":"string","description":"`ReportFilter` formula"},"data_type":{"type":"string","description":"`ReportFilter` data type"},"formula_type":{"type":"string","description":"`ReportFilter` formula type"},"filter_type":{"enum":["SINGLE","MULTI","RANGE"],"description":"`ReportFilter` type"},"control_type":{"enum":["LIST","DROPDOWN","RANGE"],"description":"`ReportFilter` control type"},"variable_type":{"enum":["CONTINUOUS","DISCRETE"],"description":"`ReportFilter` variable type"},"options":{"$ref":"#/definitions/ReportFilterOptions"},"next_filter_token":{"type":"string","description":"Token of the `ReportFilter` that should come after this one, if manual ordering is desired"}}},"CreateReportScheduleRequestBody":{"required":["cron"],"properties":{"cron":{"$ref":"#/definitions/ReportScheduleRequestBodyCronProperty"},"timeout":{"$ref":"#/definitions/ReportScheduleRequestBodyTimeoutProperty"},"params":{"$ref":"#/definitions/ReportScheduleRequestBodyParamsProperty"}}},"UpdateReportScheduleRequestBody":{"properties":{"cron":{"$ref":"#/definitions/ReportScheduleRequestBodyCronProperty"},"timeout":{"$ref":"#/definitions/ReportScheduleRequestBodyTimeoutProperty"},"params":{"$ref":"#/definitions/ReportScheduleRequestBodyParamsProperty"}}},"ReportScheduleRequestBodyTimeoutProperty":{"type":"integer","description":"How long, in seconds, the system should wait before it decides the schedule should run\n                          again even if the last run has not completed","example":3600},"ReportScheduleRequestBodyParamsProperty":{"type":"object","description":"A set of key/value pairs that match report parameter names and values, if the report for this\n                        schedule has any and you would like to schedule it with specific values","example":{"foo":"bar"}},"ReportScheduleRequestBodyCronProperty":{"type":"object","description":"CronLine attributes to determine your scheduled runtime. ","properties":{"freq":{"enum":["every_15_minutes","every_30_minutes","hourly","daily","weekly","monthly"],"description":"How often this schedule repeats","example":"hourly"},"day_of_month":{"enum":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31],"description":"The day of the month this schedule runs on","example":15},"day_of_week":{"enum":[0,1,2,3,4,5,6],"description":"The day of the week this schedule runs on (Sunday to Saturday)","example":5},"hour":{"enum":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],"description":"The hour of the day this schedule runs at (12am to 11pm)","example":8},"minute":{"enum":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59],"description":"The minute of the hour this schedules runs at","example":0},"time_zone":{"enum":["International Date Line West","Midway Island","American Samoa","Hawaii","Alaska","Pacific Time (US \u0026 Canada)","Tijuana","Mountain Time (US \u0026 Canada)","Arizona","Chihuahua","Mazatlan","Central Time (US \u0026 Canada)","Saskatchewan","Guadalajara","Mexico City","Monterrey","Central America","Eastern Time (US \u0026 Canada)","Indiana (East)","Bogota","Lima","Quito","Atlantic Time (Canada)","Caracas","La Paz","Santiago","Newfoundland","Brasilia","Buenos Aires","Montevideo","Georgetown","Puerto Rico","Greenland","Mid-Atlantic","Azores","Cape Verde Is.","Dublin","Edinburgh","Lisbon","London","Casablanca","Monrovia","UTC","Belgrade","Bratislava","Budapest","Ljubljana","Prague","Sarajevo","Skopje","Warsaw","Zagreb","Brussels","Copenhagen","Madrid","Paris","Amsterdam","Berlin","Bern","Zurich","Rome","Stockholm","Vienna","West Central Africa","Bucharest","Cairo","Helsinki","Kyiv","Riga","Sofia","Tallinn","Vilnius","Athens","Istanbul","Minsk","Jerusalem","Harare","Pretoria","Kaliningrad","Moscow","St. Petersburg","Volgograd","Samara","Kuwait","Riyadh","Nairobi","Baghdad","Tehran","Abu Dhabi","Muscat","Baku","Tbilisi","Yerevan","Kabul","Ekaterinburg","Islamabad","Karachi","Tashkent","Chennai","Kolkata","Mumbai","New Delhi","Kathmandu","Astana","Dhaka","Sri Jayawardenepura","Almaty","Novosibirsk","Rangoon","Bangkok","Hanoi","Jakarta","Krasnoyarsk","Beijing","Chongqing","Hong Kong","Urumqi","Kuala Lumpur","Singapore","Taipei","Perth","Irkutsk","Ulaanbaatar","Seoul","Osaka","Sapporo","Tokyo","Yakutsk","Darwin","Adelaide","Canberra","Melbourne","Sydney","Brisbane","Hobart","Vladivostok","Guam","Port Moresby","Magadan","Srednekolymsk","Solomon Is.","New Caledonia","Fiji","Kamchatka","Marshall Is.","Auckland","Wellington","Nuku'alofa","Tokelau Is.","Chatham Is.","Samoa"],"description":"The name of the time zone in which to evaluate the scheduled time to run","example":"Pacific Time (US \u0026 Canada)"}}},"CreateorUpdateReportSubscriptionRequestBody":{"type":"object","properties":{"csv_attachments":{"type":"boolean","description":"Whether or not to include Csv Attachments for subscribers to the scheduled run","example":true},"pdf_attachments":{"type":"boolean","description":"Whether or not to include Pdf Attachments for subscribers to the scheduled run","example":true},"data_previews":{"type":"boolean","description":"Whether or not to include Data Previews for subscribers to the scheduled run","example":true},"data_tables":{"type":"boolean","description":"Whether or not to include Data Tables for subscribers to the scheduled run","example":true},"report_links":{"type":"boolean","description":"Whether or not to include Report Links for subscribers to the scheduled run","example":true}}},"CreateSpaceMembershipRequestBody":{"required":["membership"],"type":"object","properties":{"membership":{"required":["member_type","member_token"],"type":"object","description":"The attributes of the new member being added to the space","properties":{"member_type":{"type":"string","description":"The type of member, either `\"User\"` or `\"UserGroup\"`","example":"User"},"member_token":{"type":"string","description":"The token of the member being added","example":"2bd8236f8ae4"}}}}},"CreateOrUpdateSpaceRequestBody":{"required":["space"],"type":"object","properties":{"space":{"required":["name"],"type":"object","description":"The parameters of the new or updated space","properties":{"description":{"type":"string","description":"Description of the `space`"},"name":{"type":"string","description":"Name of the `space`"}}}}},"UpdateDataSourceRequestBody":{"required":["data_source"],"type":"object","properties":{"data_source":{"type":"object","description":"The parameters of the data source to update","properties":{"name":{"type":"string","description":"Name of the `data source`","example":"Redshift Database"},"description":{"type":"string","description":"Description of the `data source`","example":"Marketing data"},"password":{"type":"string","description":"Password for the `data source`","example":"redshift_db_pw"},"custom_attributes":{"type":"object","description":"For Oracle Autonomous Database connected via bridge, pass the connection string as a custom attribute","properties":{"connection_string":{"type":"string"}}},"certificate":{"type":"file"},"key":{"type":"file"},"wallet":{"type":"file"}}}}},"VizViewVegas":{"required":["format","encoding","chartType"],"properties":{"title":{"type":"string"},"format":{"type":"object"},"encoding":{"type":"object"},"chartType":{"type":"string","example":"bigValue"}}},"VizView":{"required":["selectedChart","bar","bigNumber","line","linePlusBar","scatter","pie","area","pivotTable"],"properties":{"selectedChart":{"type":"string"},"chartIcon":{"type":"string"},"chartTitle":{"type":"string"},"bar":{"type":"object"},"bigNumber":{"type":"object"},"line":{"type":"object"},"linePlusBar":{"type":"object"},"scatter":{"type":"object"},"pie":{"type":"object"},"area":{"type":"object"},"pivotTable":{"type":"object"}}},"Link":{"required":["href"],"properties":{"href":{"type":"string"},"templated":{"type":"boolean","default":false}}},"Avatar":{"required":["type"],"properties":{"type":{"type":"string"}}},"DataSourceCustomAttributes":{"properties":{"standard_sql":{"type":"boolean"}}},"ReportRunParameters":{},"ReportFilterOptions":{},"Pagination":{"required":["first_page","last_page","total_pages","total_count"],"properties":{"first_page":{"type":"string"},"last_page":{"type":"string"},"total_pages":{"type":"integer"},"total_count":{"type":"integer"}}},"CreateUserGroupMembershipRequestBody":{"required":["membership"],"type":"object","properties":{"membership":{"description":"The parameters for the new membership","type":"object","required":["member_token"],"properties":{"member_token":{"description":"The token of the user to become a member","type":"string"}}}}},"UpdateUserGroupRequestBody":{"required":["user_group"],"type":"object","properties":{"user_group":{"description":"The parameters for the updated user group","type":"object","properties":{"name":{"description":"The new name for the user group","type":"string"}}}}},"CreateUserGroupRequestBody":{"required":["user_group"],"type":"object","properties":{"user_group":{"description":"The parameters for the created user group","type":"object","properties":{"name":{"description":"The name for the new user group","type":"string"}}}}},"Chart":{"properties":{"view":{"$ref":"#/definitions/VizView"},"view_version":{"type":"integer"},"view_vegas":{"$ref":"#/definitions/VizViewVegas"},"token":{"type":"string"},"created_at":{"type":"string"},"updated_at":{"type":"string"},"color_palette_token":{"type":"string"},"switch_view_token":{"type":"string"},"_links":{"$ref":"#/definitions/ChartLinks"},"_embedded":{"$ref":"#/definitions/ChartEmbeds"}},"required":["_links","view","view_version","view_vegas","token","created_at","updated_at"]},"ChartLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"color_palette":{"$ref":"#/definitions/Link"},"report_viz_web":{"$ref":"#/definitions/Link"},"preview":{"$ref":"#/definitions/Link"},"report_run_viz_web":{"$ref":"#/definitions/Link"},"creator":{"$ref":"#/definitions/Link"}},"required":["self","report_viz_web","preview","report_run_viz_web","creator"]},"ChartEmbeds":{},"QueryCharts":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/QueryChartsLinks"},"_embedded":{"$ref":"#/definitions/QueryChartsEmbeds"}},"required":["_links"]},"QueryChartsLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"QueryChartsEmbeds":{},"DataSource":{"properties":{"id":{"type":"integer"},"name":{"type":"string"},"description":{"type":"string"},"token":{"type":"string"},"adapter":{"enum":["jdbc:athena","jdbc:bigquery","jdbc:databricks","jdbc:dbtmetrics","jdbc:transform","jdbc:druid","jdbc:hive","jdbc:impala","jdbc:mysql","jdbc:oracle","jdbc:oracleadb","jdbc:postgresql","jdbc:trino","jdbc:presto","jdbc:redshift","jdbc:snowflake","jdbc:spark","jdbc:sqlserver","jdbc:treasuredata","jdbc:vertica"],"type":"string"},"created_at":{"type":"string"},"updated_at":{"type":"string"},"has_expensive_schema_updates":{"type":"boolean"},"public":{"type":"boolean"},"asleep":{"type":"boolean"},"queryable":{"type":"boolean"},"display_name":{"type":"string"},"account_id":{"type":"integer"},"account_username":{"type":"string"},"organization_token":{"type":"string"},"default":{"type":"boolean"},"default_for_organization_id":{"type":"boolean"},"database":{"type":"string"},"host":{"type":"string"},"port":{"type":"string"},"ssl":{"type":"boolean"},"username":{"type":"string"},"provider":{"type":"string"},"vendor":{"type":"string"},"ldap":{"type":"boolean"},"warehouse":{"type":"string"},"bridged":{"type":"boolean"},"adapter_version":{"type":"string"},"custom_attributes":{"$ref":"#/definitions/DataSourceCustomAttributes"},"ssl_trusted_cert":{"type":"string"},"default_access_level":{"type":"string"},"_links":{"$ref":"#/definitions/DataSourceLinks"},"_embedded":{"$ref":"#/definitions/DataSourceEmbeds"}},"required":["_links","id","name","description","token","adapter","created_at","updated_at","has_expensive_schema_updates","public","asleep","queryable","display_name","database","host","port","ssl","username","provider","vendor","ldap","warehouse","bridged","adapter_version","custom_attributes"]},"DataSourceLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"account":{"$ref":"#/definitions/Link"},"permissions":{"$ref":"#/definitions/Link"},"web":{"$ref":"#/definitions/Link"},"web_home":{"$ref":"#/definitions/Link"}},"required":["self","account","web","web_home"]},"DataSourceEmbeds":{},"DataSourceSchemaUpdate":{"properties":{"id":{"type":"string"},"token":{"type":"string"},"state":{"type":"string"},"content_length":{"type":"string"},"number_of_schemas":{"type":"string"},"number_of_tables":{"type":"string"},"last_succesful_refresh_at":{"type":"string"},"_links":{"$ref":"#/definitions/DataSourceSchemaUpdateLinks"},"_embedded":{"$ref":"#/definitions/DataSourceSchemaUpdateEmbeds"}},"required":["_links","id","token","state","content_length","number_of_schemas","number_of_tables"]},"DataSourceSchemaUpdateLinks":{"properties":{"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"DataSourceSchemaUpdateEmbeds":{},"DataSources":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/DataSourcesLinks"},"_embedded":{"$ref":"#/definitions/DataSourcesEmbeds"}},"required":["_links"]},"DataSourcesLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"DataSourcesEmbeds":{},"Definition":{"properties":{"id":{"type":"string"},"token":{"type":"string"},"name":{"type":"string"},"description":{"type":"string"},"source":{"type":"string"},"data_source_id":{"type":"string"},"created_at":{"type":"string"},"updated_at":{"type":"string"},"last_successful_sync_at":{"type":"string"},"github_link":{"type":"string"},"last_saved_at":{"type":"string"},"_links":{"$ref":"#/definitions/DefinitionLinks"},"_embedded":{"$ref":"#/definitions/DefinitionEmbeds"}},"required":["_links","id","token","name","description","source","data_source_id","created_at","updated_at","last_successful_sync_at","last_saved_at"]},"DefinitionLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"last_run":{"$ref":"#/definitions/Link"},"last_successful_github_sync":{"$ref":"#/definitions/Link"},"web_edit":{"$ref":"#/definitions/Link"},"creator":{"$ref":"#/definitions/Link"}},"required":["self","last_run","last_successful_github_sync","web_edit","creator"]},"DefinitionEmbeds":{},"Definitions":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/DefinitionsLinks"},"_embedded":{"$ref":"#/definitions/DefinitionsEmbeds"}},"required":["_links"]},"DefinitionsLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"DefinitionsEmbeds":{},"BadRequest":{"required":["id","message"],"properties":{"id":{"type":"string","enum":["bad_request"]},"message":{"type":"string"}}},"Forbidden":{"required":["id","message"],"properties":{"id":{"type":"string","enum":["forbidden"]},"message":{"type":"string"}}},"InternalServerError":{"required":["id","message"],"properties":{"id":{"type":"string","enum":["internal_server_error"]},"message":{"type":"string"}}},"NotFound":{"required":["id","message"],"properties":{"id":{"type":"string","enum":["not_found"]},"message":{"type":"string"}}},"ParamMissing":{"required":["id","message"],"properties":{"id":{"type":"string","enum":["param_missing"]},"message":{"type":"string"}}},"PayloadTooLarge":{"required":["id","message"],"properties":{"id":{"type":"string","enum":["payload_too_large"]},"message":{"type":"string"}}},"RateLimited":{"required":["id","message"],"properties":{"id":{"type":"string","enum":["rate_limited"]},"message":{"type":"string"}}},"ServiceUnavailable":{"required":["id","message"],"properties":{"id":{"type":"string","enum":["service_unavailable"]},"message":{"type":"string"}}},"Unauthorized":{"required":["id","message"],"properties":{"id":{"type":"string","enum":["unauthorized"]},"message":{"type":"string"}}},"FormField":{"properties":{"name":{"type":"string"},"options":{"type":"string"},"options_error":{"type":"string"},"source_size":{"type":"string"},"_links":{"$ref":"#/definitions/FormFieldLinks"},"_embedded":{"$ref":"#/definitions/FormFieldEmbeds"}},"required":["_links","name","options","options_error","source_size"]},"FormFieldLinks":{},"FormFieldEmbeds":{},"Invite":{"properties":{"email":{"type":"string"},"message":{"type":"string"},"inviter_id":{"type":"string"},"invitee_id":{"type":"string"},"organization_id":{"type":"string"},"limited":{"type":"string"},"sent_at":{"type":"string"},"resent_at":{"type":"string"},"clicked_at":{"type":"string"},"accepted_at":{"type":"string"},"expires_at":{"type":"string"},"created_at":{"type":"string"},"_links":{"$ref":"#/definitions/InviteLinks"},"_embedded":{"$ref":"#/definitions/InviteEmbeds"}},"required":["_links","email","message","inviter_id","invitee_id","organization_id","limited","expires_at","created_at"]},"InviteLinks":{"properties":{"inviter":{"$ref":"#/definitions/Link"},"invitee":{"$ref":"#/definitions/Link"},"web_self_resend":{"$ref":"#/definitions/Link"}},"required":["inviter","web_self_resend"]},"InviteEmbeds":{},"Membership":{"properties":{"admin":{"type":"boolean"},"invited":{"type":"boolean"},"state":{"type":"string"},"member_username":{"type":"string"},"member_token":{"type":"string"},"activated_at":{"type":"string"},"managed_by_scim":{"type":"boolean"},"_links":{"$ref":"#/definitions/MembershipLinks"},"_embedded":{"$ref":"#/definitions/MembershipEmbeds"}},"required":["_links","admin","state","member_username","member_token","activated_at"]},"MembershipLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"web_self":{"$ref":"#/definitions/Link"},"web_self_unban":{"$ref":"#/definitions/Link"},"web_self_approve":{"$ref":"#/definitions/Link"},"organization":{"$ref":"#/definitions/Link"},"user":{"$ref":"#/definitions/Link"},"web_self_download_profile":{"$ref":"#/definitions/Link"},"web_self_confirm_destroy":{"$ref":"#/definitions/Link"},"groups":{"$ref":"#/definitions/Link"}},"required":["self","web_self","organization","groups"]},"MembershipEmbeds":{},"Memberships":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/MembershipsLinks"},"_embedded":{"$ref":"#/definitions/MembershipsEmbeds"}},"required":["_links"]},"MembershipsLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"MembershipsEmbeds":{},"Query":{"properties":{"id":{"type":"string"},"token":{"type":"string"},"raw_query":{"type":"string"},"created_at":{"type":"string"},"updated_at":{"type":"string"},"name":{"type":"string"},"last_run_id":{"type":"string"},"data_source_id":{"type":"string"},"explorations_count":{"type":"string"},"report_imports_count":{"type":"string"},"mapping_id":{"type":"string"},"_links":{"$ref":"#/definitions/QueryLinks"},"_embedded":{"$ref":"#/definitions/QueryEmbeds"}},"required":["_links","id","token","created_at","updated_at","name","last_run_id","data_source_id","explorations_count","report_imports_count"]},"QueryLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"report":{"$ref":"#/definitions/Link"},"report_runs":{"$ref":"#/definitions/Link"},"charts":{"$ref":"#/definitions/Link"},"new_chart":{"$ref":"#/definitions/Link"},"new_query_table":{"$ref":"#/definitions/Link"},"query_tables":{"$ref":"#/definitions/Link"},"query_runs":{"$ref":"#/definitions/Link"},"creator":{"$ref":"#/definitions/Link"}},"required":["self","report","report_runs","query_runs","creator"]},"QueryEmbeds":{},"QueryRun":{"properties":{"id":{"type":"string"},"token":{"type":"string"},"raw_source":{"type":"string"},"statement_annotation":{"type":"string"},"state":{"type":"string"},"created_at":{"type":"string"},"completed_at":{"type":"string"},"data_source_id":{"type":"string"},"limit":{"type":"string"},"query_token":{"type":"string"},"query_name":{"type":"string"},"query_created_at":{"type":"string"},"parameters":{"type":"string"},"rendered_source":{"type":"string"},"max_result_bytes":{"type":"string"},"help_url":{"type":"string"},"error_code":{"type":"string"},"error_type":{"type":"string"},"error_message":{"type":"string"},"_links":{"$ref":"#/definitions/QueryRunLinks"},"_embedded":{"$ref":"#/definitions/QueryRunEmbeds"}},"required":["_links","id","token","state","created_at","completed_at","data_source_id","limit","query_token","query_name","query_created_at","parameters","max_result_bytes"]},"QueryRunLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"query":{"$ref":"#/definitions/Link"},"view":{"$ref":"#/definitions/Link"},"result":{"$ref":"#/definitions/Link"},"result_web":{"$ref":"#/definitions/Link"},"query_web":{"$ref":"#/definitions/Link"},"report_run":{"$ref":"#/definitions/Link"},"report_run_web":{"$ref":"#/definitions/Link"},"executed_by":{"$ref":"#/definitions/Link"}},"required":["self","query","result","result_web","query_web","report_run","report_run_web","executed_by"]},"QueryRunEmbeds":{},"QueryRuns":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/QueryRunsLinks"},"_embedded":{"$ref":"#/definitions/QueryRunsEmbeds"}},"required":["_links"]},"QueryRunsLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"QueryRunsEmbeds":{},"ReportFilter":{"properties":{"id":{"type":"integer"},"report_id":{"type":"integer"},"token":{"type":"string"},"name":{"type":"string"},"row_order":{"type":"integer"},"formula":{"type":"string"},"data_type":{"type":"string"},"formula_type":{"type":"string"},"hide_select_all":{"type":"string"},"filter_type":{"enum":["SINGLE","MULTI","RANGE"],"type":"string"},"control_type":{"enum":["LIST","DROPDOWN","RANGE"],"type":"string"},"variable_type":{"enum":["CONTINUOUS","DISCRETE"],"type":"string"},"options":{"$ref":"#/definitions/ReportFilterOptions"},"created_at":{"type":"string"},"updated_at":{"type":"string"},"_links":{"$ref":"#/definitions/ReportFilterLinks"},"_embedded":{"$ref":"#/definitions/ReportFilterEmbeds"}},"required":["_links","id","report_id","token","name","row_order","formula","data_type","formula_type","hide_select_all","filter_type","control_type","variable_type","options","created_at","updated_at"]},"ReportFilterLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"report":{"$ref":"#/definitions/Link"}},"required":["self","report"]},"ReportFilterEmbeds":{},"ReportFilters":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/ReportFiltersLinks"},"_embedded":{"$ref":"#/definitions/ReportFiltersEmbeds"}},"required":["_links"]},"ReportFiltersLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"ReportFiltersEmbeds":{},"ReportQueries":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/ReportQueriesLinks"},"_embedded":{"$ref":"#/definitions/ReportQueriesEmbeds"}},"required":["_links"]},"ReportQueriesLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"ReportQueriesEmbeds":{},"Report":{"properties":{"token":{"type":"string"},"id":{"type":"integer"},"name":{"type":"string"},"description":{"type":"string"},"created_at":{"type":"string"},"updated_at":{"type":"string"},"published_at":{"type":"string"},"edited_at":{"type":"string"},"theme_id":{"type":"integer"},"color_mappings":{"type":"string"},"type":{"type":"string"},"last_successful_sync_at":{"type":"string"},"last_saved_at":{"type":"string"},"archived":{"type":"boolean"},"space_token":{"type":"string"},"account_id":{"type":"integer"},"account_username":{"type":"string"},"public":{"type":"boolean"},"full_width":{"type":"boolean"},"manual_run_disabled":{"type":"boolean"},"run_privately":{"type":"boolean"},"drilldowns_enabled":{"type":"boolean"},"layout":{"type":"string"},"is_embedded":{"type":"boolean"},"is_signed":{"type":"boolean"},"shared":{"type":"boolean"},"expected_runtime":{"type":"number"},"last_successfully_run_at":{"type":"string"},"last_run_at":{"type":"string"},"web_preview_image":{"type":"string"},"last_successful_run_token":{"type":"string"},"flamingo_signature":{"type":"string"},"github_link":{"type":"string"},"query_count":{"type":"string"},"max_query_count":{"type":"string"},"chart_count":{"type":"string"},"runs_count":{"type":"string"},"schedules_count":{"type":"string"},"query_preview":{"type":"string"},"view_count":{"type":"string"},"_links":{"$ref":"#/definitions/ReportLinks"},"_embedded":{"$ref":"#/definitions/ReportEmbeds"}},"required":["_links","token","id","name","created_at","updated_at","published_at","edited_at","type","last_saved_at","archived","account_id","account_username","public","manual_run_disabled","run_privately","drilldowns_enabled","expected_runtime","last_successfully_run_at","last_run_at","last_successful_run_token","query_count","max_query_count","runs_count","query_preview","view_count"]},"ReportLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"web":{"$ref":"#/definitions/Link"},"web_edit":{"$ref":"#/definitions/Link"},"web_external_url":{"$ref":"#/definitions/Link"},"csv_export":{"$ref":"#/definitions/Link"},"share":{"$ref":"#/definitions/Link"},"web_report_runs":{"$ref":"#/definitions/Link"},"account":{"$ref":"#/definitions/Link"},"report_run":{"$ref":"#/definitions/Link"},"star":{"$ref":"#/definitions/Link"},"space":{"$ref":"#/definitions/Link"},"space_links":{"$ref":"#/definitions/Link"},"queries":{"$ref":"#/definitions/Link"},"report_runs":{"$ref":"#/definitions/Link"},"report_pins":{"$ref":"#/definitions/Link"},"report_filters":{"$ref":"#/definitions/Link"},"report_schedules":{"$ref":"#/definitions/Link"},"report_subscriptions":{"$ref":"#/definitions/Link"},"python_visualizations":{"$ref":"#/definitions/Link"},"embed_key":{"$ref":"#/definitions/Link"},"last_run":{"$ref":"#/definitions/Link"},"last_successful_run":{"$ref":"#/definitions/Link"},"python_notebook":{"$ref":"#/definitions/Link"},"perspective_email_subscription_memberships":{"$ref":"#/definitions/Link"},"validate_email_subscriber":{"$ref":"#/definitions/Link"},"creator":{"$ref":"#/definitions/Link"},"report_theme":{"$ref":"#/definitions/Link"},"last_successful_github_sync":{"$ref":"#/definitions/Link"},"report_index_web":{"$ref":"#/definitions/Link"}},"required":["self","web","account","report_run","queries","report_runs","report_pins","last_run","last_successful_run"]},"ReportEmbeds":{},"ReportRun":{"properties":{"token":{"type":"string"},"state":{"enum":["pending","enqueued","cancelled","failed","succeeded","completed","running_notebook"],"type":"string"},"parameters":{"$ref":"#/definitions/ReportRunParameters"},"created_at":{"type":"string"},"updated_at":{"type":"string"},"completed_at":{"type":"string"},"purge_started_at":{"type":"string"},"purge_completed_at":{"type":"string"},"python_state":{"enum":["none","pending","failed","submitted","succeeded"],"type":"string"},"form_fields":{"type":"array"},"flamingo_signature":{"type":"string"},"flamingo_host":{"type":"string"},"is_latest_report_run":{"type":"string"},"is_latest_successful_report_run":{"type":"string"},"report_has_failures_since_last_success":{"type":"string"},"_links":{"$ref":"#/definitions/ReportRunLinks"},"_embedded":{"$ref":"#/definitions/ReportRunEmbeds"}},"required":["_links","token","state","created_at","updated_at","completed_at","purge_started_at","purge_completed_at","flamingo_signature","flamingo_host","is_latest_report_run","is_latest_successful_report_run","report_has_failures_since_last_success"]},"ReportRunLinks":{"properties":{"latest_successful_report_run_api_url":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"},"content":{"$ref":"#/definitions/Link"},"preview":{"$ref":"#/definitions/Link"},"account":{"$ref":"#/definitions/Link"},"report_schedule":{"$ref":"#/definitions/Link"},"executed_by":{"$ref":"#/definitions/Link"},"share":{"$ref":"#/definitions/Link"},"embed":{"$ref":"#/definitions/Link"},"report":{"$ref":"#/definitions/Link"},"clone":{"$ref":"#/definitions/Link"},"query_runs":{"$ref":"#/definitions/Link"},"python_cell_runs":{"$ref":"#/definitions/Link"},"pdf_export":{"$ref":"#/definitions/Link"},"web_clone":{"$ref":"#/definitions/Link"},"web_external_url":{"$ref":"#/definitions/Link"}},"required":["self","account","executed_by","report","query_runs"]},"ReportRunEmbeds":{},"ReportRuns":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/ReportRunsLinks"},"_embedded":{"$ref":"#/definitions/ReportRunsEmbeds"}},"required":["_links"]},"ReportRunsLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"ReportRunsEmbeds":{},"Reports":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/ReportsLinks"},"_embedded":{"$ref":"#/definitions/ReportsEmbeds"}},"required":["_links"]},"ReportsLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"ReportsEmbeds":{},"ReportSchedule":{"properties":{"token":{"type":"string"},"state":{"type":"string"},"parameters":{"type":"string"},"created_at":{"type":"string"},"updated_at":{"type":"string"},"retry_state":{"type":"string"},"retry_count":{"type":"string"},"retry_delay":{"type":"string"},"timeout":{"type":"string"},"last_run_at":{"type":"string"},"last_succeeded_at":{"type":"string"},"last_scheduled_run":{"type":"string"},"next_scheduled_run":{"type":"string"},"subscribed":{"type":"string"},"_links":{"$ref":"#/definitions/ReportScheduleLinks"},"_embedded":{"$ref":"#/definitions/ReportScheduleEmbeds"}},"required":["_links","token","state","parameters","created_at","updated_at","retry_state","retry_count","retry_delay","timeout","last_run_at","last_succeeded_at","last_scheduled_run","next_scheduled_run","subscribed"]},"ReportScheduleLinks":{"properties":{"account":{"$ref":"#/definitions/Link"},"creator":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"},"report":{"$ref":"#/definitions/Link"},"report_runs":{"$ref":"#/definitions/Link"},"report_subscriptions":{"$ref":"#/definitions/Link"}},"required":["account","creator","self","report","report_runs","report_subscriptions"]},"ReportScheduleEmbeds":{},"ReportSchedules":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/ReportSchedulesLinks"},"_embedded":{"$ref":"#/definitions/ReportSchedulesEmbeds"}},"required":["_links"]},"ReportSchedulesLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"ReportSchedulesEmbeds":{},"ReportSubscription":{"properties":{"data_previews_enabled":{"type":"boolean"},"data_tables_enabled":{"type":"boolean"},"csv_attachments_enabled":{"type":"boolean"},"pdf_attachments_enabled":{"type":"boolean"},"report_links_enabled":{"type":"boolean"},"email_subscriber_count":{"type":"integer"},"_links":{"$ref":"#/definitions/ReportSubscriptionLinks"},"_embedded":{"$ref":"#/definitions/ReportSubscriptionEmbeds"}},"required":["_links","data_previews_enabled","data_tables_enabled","csv_attachments_enabled","pdf_attachments_enabled","report_links_enabled","email_subscriber_count"]},"ReportSubscriptionLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"report_schedule":{"$ref":"#/definitions/Link"},"email_subscription_memberships":{"$ref":"#/definitions/Link"},"slack_subscription_memberships":{"$ref":"#/definitions/Link"}},"required":["self","report_schedule","email_subscription_memberships","slack_subscription_memberships"]},"ReportSubscriptionEmbeds":{},"ReportSubscriptions":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/ReportSubscriptionsLinks"},"_embedded":{"$ref":"#/definitions/ReportSubscriptionsEmbeds"}},"required":["_links"]},"ReportSubscriptionsLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"ReportSubscriptionsEmbeds":{},"SpaceMemberships":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/SpaceMembershipsLinks"},"_embedded":{"$ref":"#/definitions/SpaceMembershipsEmbeds"}},"required":["_links"]},"SpaceMembershipsLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"SpaceMembershipsEmbeds":{},"SpaceMembership":{"properties":{"token":{"type":"string"},"member_token":{"type":"string"},"member_type":{"type":"string"},"member_id":{"type":"string"},"email":{"type":"string"},"_links":{"$ref":"#/definitions/SpaceMembershipLinks"},"_embedded":{"$ref":"#/definitions/SpaceMembershipEmbeds"}},"required":["_links","token","member_token","member_type","member_id"]},"SpaceMembershipLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"member":{"$ref":"#/definitions/Link"},"creator":{"$ref":"#/definitions/Link"}},"required":["self","member","creator"]},"SpaceMembershipEmbeds":{},"Space":{"properties":{"token":{"type":"string"},"id":{"type":"integer"},"space_type":{"type":"string"},"name":{"type":"string"},"description":{"type":"string"},"state":{"type":"string"},"restricted":{"type":"boolean"},"free_default":{"type":"string"},"viewable?":{"type":"string"},"viewed?":{"type":"string"},"default_access_level":{"type":"string"},"_links":{"$ref":"#/definitions/SpaceLinks"},"_embedded":{"$ref":"#/definitions/SpaceEmbeds"}},"required":["_links","token","id","space_type","name","description","state","restricted","free_default","viewable?"]},"SpaceLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"detail":{"$ref":"#/definitions/Link"},"space_report_pins":{"$ref":"#/definitions/Link"},"web":{"$ref":"#/definitions/Link"},"reports":{"$ref":"#/definitions/Link"},"creator":{"$ref":"#/definitions/Link"},"user_space_membership":{"$ref":"#/definitions/Link"},"space_memberships":{"$ref":"#/definitions/Link"},"preview_space_memberships":{"$ref":"#/definitions/Link"},"search_space_permissions":{"$ref":"#/definitions/Link"},"viewed":{"$ref":"#/definitions/Link"}},"required":["self","detail","reports","creator","search_space_permissions"]},"SpaceEmbeds":{},"Spaces":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/SpacesLinks"},"_embedded":{"$ref":"#/definitions/SpacesEmbeds"}},"required":["_links"]},"SpacesLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"SpacesEmbeds":{},"UserGroupMembership":{"properties":{"token":{"type":"string"},"member_token":{"type":"string"},"_links":{"$ref":"#/definitions/UserGroupMembershipLinks"},"_embedded":{"$ref":"#/definitions/UserGroupMembershipEmbeds"}},"required":["_links","token","member_token"]},"UserGroupMembershipLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"creator":{"$ref":"#/definitions/Link"},"member":{"$ref":"#/definitions/Link"},"user_group":{"$ref":"#/definitions/Link"}},"required":["self","creator","member","user_group"]},"UserGroupMembershipEmbeds":{},"UserGroupMemberships":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/UserGroupMembershipsLinks"},"_embedded":{"$ref":"#/definitions/UserGroupMembershipsEmbeds"}},"required":["_links"]},"UserGroupMembershipsLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"UserGroupMembershipsEmbeds":{},"UserGroup":{"properties":{"token":{"type":"string"},"group_type":{"type":"string"},"name":{"type":"string"},"description":{"type":"string"},"state":{"type":"string"},"member_count":{"type":"string"},"spaces_count":{"type":"string"},"data_sources_count":{"type":"string"},"managed":{"type":"string"},"_links":{"$ref":"#/definitions/UserGroupLinks"},"_embedded":{"$ref":"#/definitions/UserGroupEmbeds"}},"required":["_links","token","group_type","name","description","state","member_count","spaces_count","data_sources_count","managed"]},"UserGroupLinks":{"properties":{"self":{"$ref":"#/definitions/Link"},"web":{"$ref":"#/definitions/Link"},"creator":{"$ref":"#/definitions/Link"},"group_memberships":{"$ref":"#/definitions/Link"},"membership_by_id":{"$ref":"#/definitions/Link"},"memberships_preview":{"$ref":"#/definitions/Link"}},"required":["self","web","creator","group_memberships","membership_by_id","memberships_preview"]},"UserGroupEmbeds":{},"UserGroups":{"properties":{"pagination":{"$ref":"#/definitions/Pagination"},"_links":{"$ref":"#/definitions/UserGroupsLinks"},"_embedded":{"$ref":"#/definitions/UserGroupsEmbeds"}},"required":["_links"]},"UserGroupsLinks":{"properties":{"next_page":{"$ref":"#/definitions/Link"},"prev_page":{"$ref":"#/definitions/Link"},"self":{"$ref":"#/definitions/Link"}},"required":["self"]},"UserGroupsEmbeds":{}}}
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "0.0.1",
+    "title": "Mode",
+    "description": "Mode provides a REST API for many common operations, such as:\n\n* Listing spaces and reports\n* Running reports\n* Downloading query results\n\n## Authentication\n\nFor most Mode API calls, the client must supply an API token and secret for\nHTTP basic authentication.\n\nIf authentication is required for a given resource, unauthenticated requests\nwill result in a `401 Unauthorized` response.\n\n[Create and Manage API Tokens](https://modeanalytics.com/settings/access_tokens)\n",
+    "termsOfService": "https://mode.com/tos/",
+    "contact": {
+      "name": "Mode API Team",
+      "email": "support@modeanalytics.com"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "modeanalytics.com",
+  "basePath": "/api",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/hal+json"
+  ],
+  "security": [
+    {
+      "accessTokenAuth": []
+    }
+  ],
+  "securityDefinitions": {
+    "accessTokenAuth": {
+      "type": "basic"
+    }
+  },
+  "paths": {
+    "/account": {
+      "x-summary": "User",
+      "get": {
+        "operationId": "getCurrentUser",
+        "summary": "Get authorizing user",
+        "description": "Returns a representation of the authorizing `User`",
+        "responses": {
+          "200": {
+            "description": "`User` response",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/queries/{query}/charts": {
+      "x-summary": "Charts",
+      "get": {
+        "operationId": "listChartsInQuery",
+        "summary": "List Charts for a Query",
+        "description": "Returns all `Chart`s for a `Query`",
+        "responses": {
+          "200": {
+            "description": "`Chart` collection response",
+            "schema": {
+              "$ref": "#/definitions/QueryCharts"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query",
+            "in": "path",
+            "description": "`Query` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/{report}/queries/{query}/charts/{chart}": {
+      "x-summary": "Chart",
+      "get": {
+        "operationId": "getChart",
+        "summary": "Get a chart",
+        "description": "Returns a representation of a single `Chart`",
+        "responses": {
+          "200": {
+            "description": "`Chart` response",
+            "schema": {
+              "$ref": "#/definitions/Chart"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Chart` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query",
+            "in": "path",
+            "description": "`Query` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "chart",
+            "in": "path",
+            "description": "`Chart` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/data_sources/{data_source}/schema_updates": {
+      "x-summary": "DataSources",
+      "post": {
+        "operationId": "createDataSourceSchemaUpdate",
+        "summary": "Update data source schema",
+        "description": "Creates and queues a `schema update` for a `data source`",
+        "responses": {
+          "200": {
+            "description": "`DataSourceSchemaUpdate` response",
+            "schema": {
+              "$ref": "#/definitions/DataSourceSchemaUpdate"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`DataSource` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "data_source",
+            "in": "path",
+            "description": "`DataSource` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{workspace}/data_sources": {
+      "x-summary": "DataSources",
+      "get": {
+        "operationId": "listDataSources",
+        "summary": "List data sources",
+        "description": "Returns all `DataSource`s owned by a `Workspace`",
+        "responses": {
+          "200": {
+            "description": "`DataSource` collection response",
+            "schema": {
+              "$ref": "#/definitions/DataSources"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Workspace` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{workspace}/data_sources/{data_source}": {
+      "x-summary": "Data Source",
+      "get": {
+        "operationId": "getDataSource",
+        "summary": "Get a data source",
+        "description": "Returns a single `DataSource`",
+        "responses": {
+          "200": {
+            "description": "`DataSource` response",
+            "schema": {
+              "$ref": "#/definitions/DataSource"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`DataSource` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "data_source",
+            "in": "path",
+            "description": "`DataSource` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "updateDataSource",
+        "summary": "Update a data source",
+        "description": "Updates a `DataSource`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/UpdateDataSourceRequestBody"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "data_source",
+            "in": "path",
+            "description": "`DataSource` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`DataSource` response",
+            "schema": {
+              "$ref": "#/definitions/DataSource"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`DataSource` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{workspace}/data_sources/{data_source}/purge": {
+      "x-summary": "Data Source",
+      "post": {
+        "operationId": "purgeForDataSource",
+        "summary": "Purge report results",
+        "description": "Removes all report results that use a data source",
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "schema": {}
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`DataSource` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "data_source",
+            "in": "path",
+            "description": "`DataSource` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{workspace}/definitions": {
+      "x-summary": "Definitions",
+      "get": {
+        "operationId": "listDefinitions",
+        "summary": "List definitions",
+        "description": "Returns a list of `Definition`s",
+        "responses": {
+          "200": {
+            "description": "`Definitions` collection response",
+            "schema": {
+              "$ref": "#/definitions/Definitions"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "No default `Library` found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter `Definition`'s by token. Example: `?filter=by_tokens`",
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "tokens",
+            "description": "Comma separated list of `Definition` tokens",
+            "type": "string"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createDefinition",
+        "summary": "Create a definition",
+        "description": "Creates a `Definition`",
+        "responses": {
+          "200": {
+            "description": "`Definition` response",
+            "schema": {
+              "$ref": "#/definitions/Definition"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`DataSource` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{workspace}/definitions/{definition}": {
+      "x-summary": "Definition",
+      "get": {
+        "operationId": "getDefinition",
+        "summary": "Get a definition",
+        "description": "Returns a representation of `Definition`",
+        "responses": {
+          "200": {
+            "description": "`Definition` response",
+            "schema": {
+              "$ref": "#/definitions/Definition"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Definition` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "definition",
+            "in": "path",
+            "description": "`Definition` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "updateDefinition",
+        "summary": "Update a definition",
+        "description": "Updates a `Definition`",
+        "responses": {
+          "200": {
+            "description": "`Definition` response",
+            "schema": {
+              "$ref": "#/definitions/Definition"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Definition` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "definition",
+            "in": "path",
+            "description": "`Definition` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteDefinition",
+        "summary": "Delete a definition",
+        "description": "Deletes a `Definition`",
+        "responses": {
+          "200": {
+            "description": "`Definition` response",
+            "schema": {
+              "$ref": "#/definitions/Definition"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Definition` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "definition",
+            "in": "path",
+            "description": "`Definition` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{workspace}/invites": {
+      "x-summary": "Invite",
+      "post": {
+        "operationId": "createOrganizationInvite",
+        "summary": "Create an invitation",
+        "description": "Creates a `User` and invites `User` to `Workspace`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateInviteRequestBody"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`WorkspaceInvite` response",
+            "schema": {
+              "$ref": "#/definitions/Invite"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found for `Workspace`",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{workspace}/memberships": {
+      "x-summary": "Workspace Memberships",
+      "get": {
+        "operationId": "listMemberships",
+        "summary": "List memberships",
+        "description": "Returns a list of `Membership`s",
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Workspace` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{workspace}/memberships/{membership}": {
+      "x-summary": "Workspace Membership",
+      "get": {
+        "operationId": "getMembership",
+        "summary": "Get a membership",
+        "description": "Returns a representation of a `Membership`",
+        "responses": {
+          "200": {
+            "description": "`Membership` response",
+            "schema": {
+              "$ref": "#/definitions/Membership"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "membership",
+            "in": "path",
+            "description": "`Membership` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteMembership",
+        "summary": "Delete a membership",
+        "description": "Deletes a `Membership`",
+        "responses": {
+          "200": {
+            "description": "`Membership` response",
+            "schema": {
+              "$ref": "#/definitions/Membership"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "membership",
+            "in": "path",
+            "description": "`Membership` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/{report}/queries": {
+      "x-summary": "Queries",
+      "get": {
+        "operationId": "listQueriesInReport",
+        "summary": "List queries",
+        "description": "Returns all `Queries` in a `Report`",
+        "responses": {
+          "200": {
+            "description": "`Query` collection response",
+            "schema": {
+              "$ref": "#/definitions/ReportQueries"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createQueryInReport",
+        "summary": "Create a query",
+        "description": "Creates a `Query` in a `Report`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateQueryRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`Query` response",
+            "schema": {
+              "$ref": "#/definitions/Query"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/queries/{query}": {
+      "x-summary": "Query",
+      "get": {
+        "operationId": "getQueryInReport",
+        "summary": "Get a query",
+        "description": "Returns a `Query` in a `Report`",
+        "responses": {
+          "200": {
+            "description": "`Query` response",
+            "schema": {
+              "$ref": "#/definitions/Query"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query",
+            "in": "path",
+            "description": "`Query` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "updateQueryInReport",
+        "summary": "Upate a query",
+        "description": "Updates a `Query` in a `Report`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/UpdateQueryRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query",
+            "in": "path",
+            "description": "`Query` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`Query` response",
+            "schema": {
+              "$ref": "#/definitions/Query"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteQueryInReport",
+        "summary": "Delete a query",
+        "description": "Deletes a `Query` in a `Report`",
+        "responses": {
+          "200": {
+            "description": "`Query` response",
+            "schema": {
+              "$ref": "#/definitions/Query"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query",
+            "in": "path",
+            "description": "`Query` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/{report}/runs/{run}/query_runs": {
+      "x-summary": "Query Runs",
+      "get": {
+        "operationId": "listQueryRunsForReportRun",
+        "summary": "List query runs",
+        "description": "Returns all `QueryRun`s for a single `ReportRun`",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "run",
+            "in": "path",
+            "description": "`ReportRun` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`QueryRun` collection response",
+            "schema": {
+              "$ref": "#/definitions/QueryRuns"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportRun` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/runs/{run}/query_runs/{query_run}": {
+      "x-summary": "Query Runs",
+      "get": {
+        "operationId": "getQueryRunForReportRun",
+        "summary": "Get a query run",
+        "description": "Returns a `QueryRun` for a single `ReportRun`",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "run",
+            "in": "path",
+            "description": "`ReportRun` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query_run",
+            "in": "path",
+            "description": "`Query Run` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`Query Run`response",
+            "schema": {
+              "$ref": "#/definitions/QueryRun"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportRun` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/runs/{run}/query_runs/{query_run}/results/content(.csv, .json)": {
+      "x-summary": "Export",
+      "get": {
+        "operationId": "getQueryRunContent",
+        "summary": "Get query results",
+        "description": "Gets the content of a query run in the requested format (csv or json)",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "run",
+            "in": "path",
+            "description": "`ReportRun` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "query_run",
+            "in": "path",
+            "description": "`Query Run` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`Query Run` result content in the requested format"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportRun` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/filters": {
+      "x-summary": "Report Filters",
+      "get": {
+        "operationId": "listReportFilters",
+        "summary": "List report filters",
+        "description": "Returns all `ReportFilter`s for a single `Report`",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`ReportFilter` collection response",
+            "schema": {
+              "$ref": "#/definitions/ReportFilters"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createReportFilter",
+        "summary": "Create a report filter",
+        "description": "Creates a `ReportFilter`",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "`ReportFilter` attributes",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateOrUpdateReportFilterRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`ReportFilter` response",
+            "schema": {
+              "$ref": "#/definitions/ReportFilter"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/filters/{filter}": {
+      "x-summary": "Report Filter",
+      "get": {
+        "operationId": "getReportFilter",
+        "summary": "Get a report filter",
+        "description": "Gets a `ReportFilter`",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "path",
+            "description": "`ReportFilter` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`ReportFilter` response",
+            "schema": {
+              "$ref": "#/definitions/ReportFilter"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportFilter` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateReportFilter",
+        "summary": "Update a report filter",
+        "description": "Updates a `ReportFilter`",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "`ReportFilter` attributes",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CreateOrUpdateReportFilterRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "path",
+            "description": "`ReportFilter` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`ReportFilter` response",
+            "schema": {
+              "$ref": "#/definitions/ReportFilter"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportFilter` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteReportFilter",
+        "summary": "Delete a report filter",
+        "description": "Deletes a `ReportFilter`",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "path",
+            "description": "`ReportFilter` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`ReportFilter` response",
+            "schema": {
+              "$ref": "#/definitions/ReportFilter"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportFilter` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/exports/runs/{run}/pdf/download": {
+      "x-summary": "Export",
+      "get": {
+        "operationId": "getReportRunExport",
+        "summary": "Get PDF of a report run",
+        "description": "Gets exported pdf of the report run",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "run",
+            "in": "path",
+            "description": "`ReportRun` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The data stream containing the exported pdf file"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportRun` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/spaces/{space}/reports": {
+      "x-summary": "Reports",
+      "get": {
+        "operationId": "listReportsInSpace",
+        "summary": "List reports for a space",
+        "description": "Returns all `Report`s in a `Space`",
+        "responses": {
+          "200": {
+            "description": "`Report` collection response",
+            "schema": {
+              "$ref": "#/definitions/Reports"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "space",
+            "in": "path",
+            "description": "`Space` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Returns a filtered list of `Report`s in a `Space` filtered by whether their `created_at` or `updated_at` timestamps are `gt` (greater than) or `lt` (less than) the datetime passed in (ISO8601 format). Example: `?filter=created_at.gt.2019-10-23T06:23:01Z` returns all `Reports` in a space created after that date.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "With the `order_by` param, returns all `Report`s in a `Space` ordered in `asc` or `desc` order. Example: `?order=asc&order_by=created_at`",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "order_by",
+            "in": "query",
+            "description": "With the `order` param, returns all `Report`s in a `Space` ordered by their `created_at` or `updated_at` timestamps. Example: `?order_by=created_at&order=asc`",
+            "required": false,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/data_sources/{data_source}/reports": {
+      "x-summary": "Reports",
+      "get": {
+        "operationId": "listReportsUsingDataSource",
+        "summary": "List reports using a data source",
+        "description": "Returns all `Report`s using a `DataSource`",
+        "responses": {
+          "200": {
+            "description": "`Report` collection response",
+            "schema": {
+              "$ref": "#/definitions/Reports"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "data_source",
+            "in": "path",
+            "description": "`DataSource` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Returns a filtered list of `Report`s in a `Space` filtered by whether their `created_at` or `updated_at` timestamps are `gt` (greater than) or `lt` (less than) the datetime passed in (ISO8601 format). Example: `?filter=created_at.gt.2019-10-23T06:23:01Z` returns all `Reports` in a space created after that date.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "With the `order_by` param, returns all `Report`s in a `Space` ordered in `asc` or `desc` order. Example: `?order=asc&order_by=created_at`",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "order_by",
+            "in": "query",
+            "description": "With the `order` param, returns all `Report`s in a `Space` ordered by their `created_at` or `updated_at` timestamps. Example: `?order_by=created_at&order=asc`",
+            "required": false,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/{report}": {
+      "x-summary": "Report",
+      "patch": {
+        "operationId": "updateReport",
+        "summary": "Update a report",
+        "description": "Updates a single `report` with the provided attributes",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/UpdateReportRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`Report` response",
+            "schema": {
+              "$ref": "#/definitions/Report"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "getReport",
+        "summary": "Get a report",
+        "description": "Returns a representation of a single `Report`",
+        "responses": {
+          "200": {
+            "description": "`Report` response",
+            "schema": {
+              "$ref": "#/definitions/Report"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteReport",
+        "summary": "Delete a report",
+        "description": "Deletes a single `Report`",
+        "responses": {
+          "200": {
+            "description": "Empty body"
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/{report}/archive": {
+      "x-summary": "Report",
+      "patch": {
+        "operationId": "archiveReport",
+        "summary": "Archive a report",
+        "description": "Archives a single `Report`",
+        "responses": {
+          "200": {
+            "description": "`Report` response",
+            "schema": {
+              "$ref": "#/definitions/Report"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/{report}/unarchive": {
+      "x-summary": "Report",
+      "patch": {
+        "operationId": "unarchiveReport",
+        "summary": "Unarchive a report",
+        "description": "Unarchives a single `Report`",
+        "responses": {
+          "200": {
+            "description": "`Report` response",
+            "schema": {
+              "$ref": "#/definitions/Report"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/purge": {
+      "x-summary": "Report",
+      "post": {
+        "operationId": "purgeAllReports",
+        "summary": "Purge all report results",
+        "description": "Removes all report results for an organization",
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "schema": {}
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Account` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/{report}/schedules": {
+      "x-summary": "ReportSchedule",
+      "get": {
+        "operationId": "listReportSchedules",
+        "summary": "List schedules for a report",
+        "description": "Returns all `Schedule`s for a `Report`",
+        "responses": {
+          "200": {
+            "description": "Report `Schedule` collection response",
+            "schema": {
+              "$ref": "#/definitions/ReportSchedules"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createReportSchedule",
+        "summary": "Create a report schedule",
+        "description": "Creates a `Report` `Schedule`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateReportScheduleRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Report `Schedule` response",
+            "schema": {
+              "$ref": "#/definitions/ReportSchedule"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/schedules/{schedule}": {
+      "x-summary": "ReportSchedule",
+      "get": {
+        "operationId": "getReportSchedule",
+        "summary": "Get a report schedule",
+        "description": "Returns a `Report`'s `Schedule`",
+        "responses": {
+          "200": {
+            "description": "Report `Schedule` response",
+            "schema": {
+              "$ref": "#/definitions/ReportSchedule"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportSchedule` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "schedule",
+            "in": "path",
+            "description": "`Schedule` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "updateReportSchedule",
+        "summary": "Update a report schedule",
+        "description": "Updates a `Report`'s `Schedule`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/UpdateReportScheduleRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "schedule",
+            "in": "path",
+            "description": "`Schedule` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Report `Schedule` response",
+            "schema": {
+              "$ref": "#/definitions/ReportSchedule"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportSchedule` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteReportSchedule",
+        "summary": "Delete a report schedule",
+        "description": "Deletes a `Report`'s `Schedule`",
+        "responses": {
+          "200": {
+            "description": "Empty body"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportSchedule` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "schedule",
+            "in": "path",
+            "description": "`Schedule` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/{report}/subscriptions": {
+      "x-summary": "Report Subscription",
+      "get": {
+        "operationId": "listSubscriptionsForReport",
+        "summary": "List subscriptions",
+        "description": "Returns all `Subscriptions` for a `Report`",
+        "responses": {
+          "200": {
+            "description": "`ReportSubscription` collection response",
+            "schema": {
+              "$ref": "#/definitions/ReportSubscriptions"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createSubscriptionForReport",
+        "summary": "Create subscription",
+        "description": "Creates and returns a `Subscription` for a `Report`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateorUpdateReportSubscriptionRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`ReportSubscription` response",
+            "schema": {
+              "$ref": "#/definitions/ReportSubscription"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/subscriptions/{subscription}": {
+      "x-summary": "Report Subscription",
+      "get": {
+        "operationId": "getSubscriptionForReport",
+        "summary": "Get subscription",
+        "description": "Returns a `Subscription` for a `Report`",
+        "responses": {
+          "200": {
+            "description": "`ReportSubscription` response",
+            "schema": {
+              "$ref": "#/definitions/ReportSubscription"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportSubscription` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subscription",
+            "in": "path",
+            "description": "`ReportSubscription` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "updateSubscriptionForReport",
+        "summary": "Update subscription",
+        "description": "Updates and returns a `Subscription` for a `Report`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateorUpdateReportSubscriptionRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subscription",
+            "in": "path",
+            "description": "`ReportSubscription` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`ReportSubscription` response",
+            "schema": {
+              "$ref": "#/definitions/ReportSubscription"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportSubscription` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteSubscriptionForReport",
+        "summary": "Delete subscription",
+        "description": "Deletes a `Subscription` for a `Report`",
+        "responses": {
+          "200": {
+            "description": "Empty body"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportSubscription` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subscription",
+            "in": "path",
+            "description": "`ReportSubscription` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/{report}/schedules/{schedule}/subscriptions": {
+      "x-summary": "Report Subscriptions",
+      "get": {
+        "operationId": "listSubscriptionsForReportSchedule",
+        "summary": "List schedule subscriptions",
+        "description": "Returns all `subscriptions` for a `Report` `Schedule`",
+        "responses": {
+          "200": {
+            "description": "`ReportSubscription` collection response",
+            "schema": {
+              "$ref": "#/definitions/ReportSubscriptions"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportSchedule` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "schedule",
+            "in": "path",
+            "description": "`Schedule` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/reports/{report}/runs": {
+      "x-summary": "Report Runs",
+      "post": {
+        "operationId": "runReport",
+        "summary": "Create a report run",
+        "description": "Runs a single `Report` and returns a representation of the resulting `ReportRun`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Custom parameter attributes",
+            "schema": {
+              "$ref": "#/definitions/RunReportRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "`ReportRun` Accepted",
+            "schema": {
+              "$ref": "#/definitions/ReportRun"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Report` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listReportRuns",
+        "summary": "List report runs",
+        "description": "Returns a list of `ReportRun`s for a `Report`",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Returns a filtered list of `Runs`s for a `Report` filtered by whether their `created_at` or `updated_at` timestamps are `gt` (greater than) or `lt` (less than) the datetime passed in (ISO8601 format). Example: `?filter=updated_at.lt.2019-10-23T06:23:01Z` returns all `Runs` in a space created before that date.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "With the `order` param, returns all `ReportRun`s for a `Report` ordered by their `created_at` or `updated_at` timestamps",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "order_by",
+            "in": "query",
+            "description": "With the `order_by` param, returns all `ReportRun`s for a `Report` ordered in `asc` or `desc` order",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`ReportRun` collection response",
+            "schema": {
+              "$ref": "#/definitions/ReportRuns"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportRun` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/runs/{run}/clone": {
+      "x-summary": "Report Run",
+      "post": {
+        "operationId": "cloneReportRun",
+        "summary": "Clone a report run",
+        "description": "Returns a representation of the cloned `ReportRun`",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "run",
+            "in": "path",
+            "description": "`ReportRun` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`Report` response",
+            "schema": {
+              "$ref": "#/definitions/Report"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportRun` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/runs/{run}/options": {
+      "x-summary": "Form Fields",
+      "get": {
+        "operationId": "listFormFields",
+        "summary": "List form fields",
+        "description": "Returns a list of Form Fields for a `ReportRun`",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "run",
+            "in": "path",
+            "description": "`ReportRun` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`FormField` collection response",
+            "schema": {
+              "$ref": "#/definitions/FormField"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportRun` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/runs/{run}": {
+      "x-summary": "Report Run",
+      "get": {
+        "operationId": "getReportRun",
+        "summary": "Get a report run",
+        "description": "Returns a representation of a single `ReportRun`",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "run",
+            "in": "path",
+            "description": "`ReportRun` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`ReportRun` response",
+            "schema": {
+              "$ref": "#/definitions/ReportRun"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportRun` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/reports/{report}/runs/{run}/results/content(.csv, .json)": {
+      "x-summary": "Export",
+      "get": {
+        "operationId": "getReportRunContent",
+        "summary": "Get report results",
+        "description": "Gets the content of a report run in the requested format (csv or json)",
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "report",
+            "in": "path",
+            "description": "`Report` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "run",
+            "in": "path",
+            "description": "`ReportRun` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`Report Run` result content in the requested format"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`ReportRun` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{account}/spaces/{space}/memberships": {
+      "x-summary": "Space Memberships",
+      "post": {
+        "operationId": "createSpaceMemberships",
+        "summary": "Create a space membership",
+        "description": "Returns all `Memberships` for a `Space`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateSpaceMembershipRequestBody"
+            }
+          },
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "space",
+            "in": "path",
+            "description": "`Space` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`SpaceMembership` response",
+            "schema": {
+              "$ref": "#/definitions/SpaceMembership"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Space` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "listSpaceMemberships",
+        "summary": "List space memberships",
+        "description": "Returns all `Memberships` for a `Space`",
+        "responses": {
+          "200": {
+            "description": "`SpaceMembership` collection response",
+            "schema": {
+              "$ref": "#/definitions/SpaceMemberships"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Space` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "space",
+            "in": "path",
+            "description": "`Space` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{account}/spaces/{space}/memberships/{space_membership}": {
+      "x-summary": "Space Membership",
+      "get": {
+        "operationId": "getSpaceMembership",
+        "summary": "Get a space membership",
+        "description": "Returns a single `Membership` for a `Space`",
+        "responses": {
+          "200": {
+            "description": "`SpaceMembership` response",
+            "schema": {
+              "$ref": "#/definitions/SpaceMembership"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Space Membership` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "space",
+            "in": "path",
+            "description": "`Space` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "space_membership",
+            "in": "path",
+            "description": "`Space Membership` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteSpaceMembership",
+        "summary": "Delete a space membership",
+        "description": "Delets a single `Membership` for a `Space`",
+        "responses": {
+          "200": {
+            "description": "`SpaceMembership` response",
+            "schema": {
+              "$ref": "#/definitions/SpaceMembership"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Space Membership` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "account",
+            "in": "path",
+            "description": "`Account` (`Workspace` or `User`) username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "space",
+            "in": "path",
+            "description": "`Space` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "space_membership",
+            "in": "path",
+            "description": "`Space Membership` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "/{workspace}/spaces": {
+      "x-summary": "Collection",
+      "get": {
+        "operationId": "listCollections",
+        "summary": "List Collections",
+        "description": "Returns a representation of `Collection`s in a `Workspace` visible to the authenticated `User`",
+        "responses": {
+          "200": {
+            "description": "`Space` collection response",
+            "schema": {
+              "$ref": "#/definitions/Spaces"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Workspace` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Returns a filtered list of `Collection`s. Valid options include `all`. The default returns a list of `Collection`'s that do not include other user's personal collections. Example: `?filter=all` returns all `Collections` including personal collections.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createCollection",
+        "summary": "Create a Collection",
+        "description": "Creates a `Collection`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateOrUpdateSpaceRequestBody"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`Space` response",
+            "schema": {
+              "$ref": "#/definitions/Space"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Account` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{workspace}/spaces/{space}": {
+      "x-summary": "Collection",
+      "get": {
+        "operationId": "getCollection",
+        "summary": "Get a Collection",
+        "description": "Returns a representation of a single `Collection`",
+        "responses": {
+          "200": {
+            "description": "`Space` response",
+            "schema": {
+              "$ref": "#/definitions/Space"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Space` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "space",
+            "in": "path",
+            "description": "`Space` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteCollection",
+        "summary": "Delete a Collection",
+        "description": "Deletes a single `Collection`",
+        "responses": {
+          "200": {
+            "description": "`Space` response",
+            "schema": {
+              "$ref": "#/definitions/Space"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "404": {
+            "description": "`Space` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "space",
+            "in": "path",
+            "description": "`Space` token",
+            "required": true,
+            "type": "string"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "updateCollection",
+        "summary": "Update a Collection",
+        "description": "Updates a `Collection`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateOrUpdateSpaceRequestBody"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "space",
+            "in": "path",
+            "description": "`Space` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`Space` response",
+            "schema": {
+              "$ref": "#/definitions/Space"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Space` not found",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{workspace}/groups/{group_token}/memberships": {
+      "x-summary": "Group Memberships",
+      "get": {
+        "operationId": "listGroupMemberships",
+        "summary": "List group memberships",
+        "description": "Get all `Memberships` of a `Group`",
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "group_token",
+            "in": "path",
+            "description": "`UserGroup` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`UserGroupMembership` collection response",
+            "schema": {
+              "$ref": "#/definitions/UserGroupMemberships"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found for `Workspace`",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createGroupMembership",
+        "summary": "Create a group membership",
+        "description": "Create a `Group` `Membership` for a given `User`",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateUserGroupMembershipRequestBody"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "group_token",
+            "in": "path",
+            "description": "`UserGroup` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`UserGroupMembership` response",
+            "schema": {
+              "$ref": "#/definitions/UserGroupMembership"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found for `Workspace`",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{workspace}/groups/{group_token}/memberships/{membership_token}": {
+      "x-summary": "Group Membership",
+      "get": {
+        "operationId": "getGroupMembership",
+        "summary": "Get a group membership",
+        "description": "Get the `Group` `Membership` of a `User`",
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "group_token",
+            "in": "path",
+            "description": "`UserGroup` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "membership_token",
+            "in": "path",
+            "description": "`UserGroupMembership token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`UserGroupMembership` response",
+            "schema": {
+              "$ref": "#/definitions/UserGroupMembership"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found for `Workspace`",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteGroupMembership",
+        "summary": "Delete a group membership",
+        "description": "Remove a `User` from a `Group` by deleting the `Membership`",
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "group_token",
+            "in": "path",
+            "description": "`UserGroup` token",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "membership_token",
+            "in": "path",
+            "description": "`UserGroupMembership token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`UserGroupMembership` response",
+            "schema": {
+              "$ref": "#/definitions/UserGroupMembership"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found for `Workspace`",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{workspace}/groups": {
+      "x-summary": "Groups",
+      "get": {
+        "operationId": "listGroups",
+        "summary": "List groups",
+        "description": "Get all `Group`s for a `Workspace`",
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`UserGroup` collection response",
+            "schema": {
+              "$ref": "#/definitions/UserGroups"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found for `Workspace`",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createGroup",
+        "summary": "Create a group",
+        "description": "Create a user `Group` with the provided attributes",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/CreateUserGroupRequestBody"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`UserGroup` response",
+            "schema": {
+              "$ref": "#/definitions/UserGroup"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found for `Workspace`",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    },
+    "/{workspace}/groups/{group_token}": {
+      "x-summary": "Group",
+      "get": {
+        "operationId": "getGroup",
+        "summary": "Get a group",
+        "description": "Gets a user `Group`",
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "group_token",
+            "in": "path",
+            "description": "`UserGroup` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`UserGroup` response",
+            "schema": {
+              "$ref": "#/definitions/UserGroup"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found for `Workspace`",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteGroup",
+        "summary": "Delete a group",
+        "description": "Deletes a user `Group`",
+        "parameters": [
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "group_token",
+            "in": "path",
+            "description": "`UserGroup` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`UserGroup` response",
+            "schema": {
+              "$ref": "#/definitions/UserGroup"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found for `Workspace`",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateGroup",
+        "summary": "Update a group",
+        "description": "Update a user `Group` with the provided attributes",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/UpdateUserGroupRequestBody"
+            }
+          },
+          {
+            "name": "workspace",
+            "in": "path",
+            "description": "`Workspace` username",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "group_token",
+            "in": "path",
+            "description": "`UserGroup` token",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "`UserGroup` response",
+            "schema": {
+              "$ref": "#/definitions/UserGroup"
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "$ref": "#/definitions/BadRequest"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/Unauthorized"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/Forbidden"
+            }
+          },
+          "404": {
+            "description": "`Membership` not found for `Workspace`",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Account": {
+      "properties": {
+        "username": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "token": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "dataset_size_limit_mb": {
+          "type": "string"
+        },
+        "query_run_size_limit_mb": {
+          "type": "string"
+        },
+        "email_verified": {
+          "type": "boolean"
+        },
+        "avatar": {
+          "$ref": "#/definitions/Avatar"
+        },
+        "user": {
+          "type": "boolean"
+        },
+        "space_count": {
+          "type": "integer"
+        },
+        "data_source_count": {
+          "type": "integer"
+        },
+        "organizations_count": {
+          "type": "string"
+        },
+        "trial_state": {
+          "enum": [
+            "pending",
+            "active",
+            "expired"
+          ],
+          "type": "string"
+        },
+        "membership_type": {
+          "enum": [
+            "admin",
+            "full"
+          ],
+          "type": "string"
+        },
+        "payment_method_confirmed": {
+          "type": "boolean"
+        },
+        "private_definition_count": {
+          "type": "integer"
+        },
+        "private_definition_limit": {
+          "type": "integer"
+        },
+        "authorized_domains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "plan_code": {
+          "enum": [
+            "standard",
+            "plus",
+            "free"
+          ],
+          "type": "string"
+        },
+        "admin_data_source_connections_only": {
+          "type": "boolean"
+        },
+        "scim_enabled": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "settings": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/AccountLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/AccountEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "username",
+        "name",
+        "id",
+        "token",
+        "dataset_size_limit_mb",
+        "query_run_size_limit_mb",
+        "avatar",
+        "user",
+        "created_at"
+      ]
+    },
+    "AccountLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "web": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_settings": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_data_sources_settings": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_settings_slack": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_public_datasource_home": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_spaces": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_groups": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_new_organization": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_membership_events": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_member_sessions": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_settings_themes": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_trial_appointments": {
+          "$ref": "#/definitions/Link"
+        },
+        "data_sources": {
+          "$ref": "#/definitions/Link"
+        },
+        "data_source": {
+          "$ref": "#/definitions/Link"
+        },
+        "admins": {
+          "$ref": "#/definitions/Link"
+        },
+        "memberships": {
+          "$ref": "#/definitions/Link"
+        },
+        "all_memberships": {
+          "$ref": "#/definitions/Link"
+        },
+        "home_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "home_starred_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "home_explorations_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "home_reports_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "home_search_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "home_discover_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "select_data_sources_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "data_source_connection_request_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "new_invite_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "new_upload_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "billing_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "public_data_sources": {
+          "$ref": "#/definitions/Link"
+        },
+        "organizations": {
+          "$ref": "#/definitions/Link"
+        },
+        "preference": {
+          "$ref": "#/definitions/Link"
+        },
+        "table": {
+          "$ref": "#/definitions/Link"
+        },
+        "report": {
+          "$ref": "#/definitions/Link"
+        },
+        "reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "archived_reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "public_reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "drafts_reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "starred_reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "by_ids_reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "viewed_reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "starred_datasets": {
+          "$ref": "#/definitions/Link"
+        },
+        "by_ids_datasets": {
+          "$ref": "#/definitions/Link"
+        },
+        "viewed_datasets": {
+          "$ref": "#/definitions/Link"
+        },
+        "starred_base_reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "by_ids_base_reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "viewed_base_reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "by_tokens_definitions": {
+          "$ref": "#/definitions/Link"
+        },
+        "bridges": {
+          "$ref": "#/definitions/Link"
+        },
+        "access_tokens": {
+          "$ref": "#/definitions/Link"
+        },
+        "new_report": {
+          "$ref": "#/definitions/Link"
+        },
+        "new_report_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "validate_table": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_views": {
+          "$ref": "#/definitions/Link"
+        },
+        "groups": {
+          "$ref": "#/definitions/Link"
+        },
+        "group": {
+          "$ref": "#/definitions/Link"
+        },
+        "everyone_group": {
+          "$ref": "#/definitions/Link"
+        },
+        "users_groups_with_data_source_entitlements": {
+          "$ref": "#/definitions/Link"
+        },
+        "spaces": {
+          "$ref": "#/definitions/Link"
+        },
+        "space": {
+          "$ref": "#/definitions/Link"
+        },
+        "custom_spaces": {
+          "$ref": "#/definitions/Link"
+        },
+        "move_to_spaces": {
+          "$ref": "#/definitions/Link"
+        },
+        "definitions": {
+          "$ref": "#/definitions/Link"
+        },
+        "definition": {
+          "$ref": "#/definitions/Link"
+        },
+        "color_palettes": {
+          "$ref": "#/definitions/Link"
+        },
+        "all_color_palettes": {
+          "$ref": "#/definitions/Link"
+        },
+        "color_palette": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_color_palettes_settings": {
+          "$ref": "#/definitions/Link"
+        },
+        "validate_space_name": {
+          "$ref": "#/definitions/Link"
+        },
+        "validate_definition_name": {
+          "$ref": "#/definitions/Link"
+        },
+        "slack_app": {
+          "$ref": "#/definitions/Link"
+        },
+        "default_categorical_palette": {
+          "$ref": "#/definitions/Link"
+        },
+        "default_sequential_palette": {
+          "$ref": "#/definitions/Link"
+        },
+        "default_divergent_palette": {
+          "$ref": "#/definitions/Link"
+        },
+        "trial_appointment": {
+          "$ref": "#/definitions/Link"
+        },
+        "member_session_timeout": {
+          "$ref": "#/definitions/Link"
+        },
+        "easy_identity_providers": {
+          "$ref": "#/definitions/Link"
+        },
+        "saml_identity_providers": {
+          "$ref": "#/definitions/Link"
+        },
+        "scim_token": {
+          "$ref": "#/definitions/Link"
+        },
+        "memberships_lite": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "web",
+        "web_public_datasource_home",
+        "web_groups",
+        "web_new_organization",
+        "home_web",
+        "home_starred_web",
+        "home_explorations_web",
+        "home_search_web",
+        "new_invite_web",
+        "new_upload_web",
+        "report",
+        "reports",
+        "archived_reports",
+        "public_reports",
+        "drafts_reports",
+        "starred_reports",
+        "by_ids_reports",
+        "viewed_reports",
+        "all_color_palettes"
+      ]
+    },
+    "AccountEmbeds": {
+      "properties": {
+        "data_sources": {
+          "$ref": "#/definitions/DataSources"
+        },
+        "spaces": {
+          "$ref": "#/definitions/Spaces"
+        },
+        "all_spaces": {
+          "$ref": "#/definitions/Spaces"
+        }
+      }
+    },
+    "RunReportRequestBody": {
+      "required": [
+        "parameters"
+      ],
+      "type": "object",
+      "properties": {
+        "parameters": {
+          "description": "A object of key/value pairs corresponding to custom report parameter names and values",
+          "type": "object",
+          "example": {
+            "user_id": 123,
+            "location": "San Francisco"
+          }
+        }
+      }
+    },
+    "QueriesAttributes": {
+      "required": [
+        "data_source_id",
+        "create_query_run"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the `Query`"
+        },
+        "data_source_id": {
+          "type": "integer",
+          "description": "Numeric ID of the `DataSource` which this `Query` should be associated with"
+        },
+        "create_query_run": {
+          "type": "boolean",
+          "description": "Determines whether to include this `Query` when running the `Report`"
+        },
+        "limit": {
+          "type": "boolean",
+          "description": "Determines whether a limit of 100 will be automatically applied to the `Query`",
+          "default": false
+        },
+        "token": {
+          "type": "string",
+          "description": "Identifying token of the `Query`, if it has already been created"
+        },
+        "raw_query": {
+          "type": "string",
+          "description": "SQL to run"
+        }
+      }
+    },
+    "CreateInviteRequestBody": {
+      "required": [
+        "invite"
+      ],
+      "type": "object",
+      "properties": {
+        "invite": {
+          "required": [
+            "invitee",
+            "message"
+          ],
+          "type": "object",
+          "properties": {
+            "invitee": {
+              "required": [
+                "email"
+              ],
+              "type": "object",
+              "properties": {
+                "email": {
+                  "type": "string",
+                  "example": "harold.ceramicist@example.com"
+                }
+              }
+            },
+            "message": {
+              "type": "string",
+              "example": "You are an analyst, Harry!"
+            }
+          }
+        }
+      }
+    },
+    "CreateQueryRequestBody": {
+      "required": [
+        "query"
+      ],
+      "type": "object",
+      "properties": {
+        "query": {
+          "required": [
+            "raw_query",
+            "data_source_id"
+          ],
+          "type": "object",
+          "description": "The parameters for the new `query`",
+          "properties": {
+            "data_source_id": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "The id of the data source to use"
+            },
+            "raw_query": {
+              "type": "string",
+              "example": "SELECT * from the_way_down",
+              "description": "The raw query to be executed"
+            },
+            "name": {
+              "type": "string",
+              "example": "Turtles",
+              "description": "The name of the new `query`"
+            }
+          }
+        }
+      }
+    },
+    "UpdateQueryRequestBody": {
+      "required": [
+        "query"
+      ],
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "object",
+          "description": "The updated parameters for the `query`",
+          "properties": {
+            "data_source_id": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "The id of the data source to use"
+            },
+            "raw_query": {
+              "type": "string",
+              "example": "SELECT * FROM small_table;",
+              "description": "The raw query to be executed"
+            },
+            "name": {
+              "type": "string",
+              "example": "All the small things",
+              "description": "The name of the new `query`"
+            }
+          }
+        }
+      }
+    },
+    "UpdateReportRequestBody": {
+      "required": [
+        "report"
+      ],
+      "type": "object",
+      "properties": {
+        "report": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of the report",
+              "example": "Kanto Region Diaspora"
+            },
+            "description": {
+              "type": "string",
+              "description": "A description of the report in question",
+              "example": "An analysis of all the creatures living in the region. Please contribute any missing data. Pocket version coming soon."
+            },
+            "space_token": {
+              "type": "string",
+              "description": "The token of the space this report will be moved to",
+              "example": "5a4177a2902c"
+            }
+          }
+        }
+      }
+    },
+    "CreateOrUpdateReportFilterRequestBody": {
+      "required": [
+        "report_filter"
+      ],
+      "properties": {
+        "report_filter": {
+          "$ref": "#/definitions/CreateOrUpdateReportFilterAttributes"
+        }
+      }
+    },
+    "CreateOrUpdateReportFilterAttributes": {
+      "required": [
+        "name",
+        "formula",
+        "data_type",
+        "formula_type",
+        "variable_type",
+        "filter_type",
+        "control_type",
+        "options"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "`ReportFilter` name"
+        },
+        "formula": {
+          "type": "string",
+          "description": "`ReportFilter` formula"
+        },
+        "data_type": {
+          "type": "string",
+          "description": "`ReportFilter` data type"
+        },
+        "formula_type": {
+          "type": "string",
+          "description": "`ReportFilter` formula type"
+        },
+        "filter_type": {
+          "enum": [
+            "SINGLE",
+            "MULTI",
+            "RANGE"
+          ],
+          "description": "`ReportFilter` type"
+        },
+        "control_type": {
+          "enum": [
+            "LIST",
+            "DROPDOWN",
+            "RANGE"
+          ],
+          "description": "`ReportFilter` control type"
+        },
+        "variable_type": {
+          "enum": [
+            "CONTINUOUS",
+            "DISCRETE"
+          ],
+          "description": "`ReportFilter` variable type"
+        },
+        "options": {
+          "$ref": "#/definitions/ReportFilterOptions"
+        },
+        "next_filter_token": {
+          "type": "string",
+          "description": "Token of the `ReportFilter` that should come after this one, if manual ordering is desired"
+        }
+      }
+    },
+    "CreateReportScheduleRequestBody": {
+      "required": [
+        "cron"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
+        },
+        "cron": {
+          "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
+        },
+        "timeout": {
+          "$ref": "#/definitions/ReportScheduleRequestBodyTimeoutProperty"
+        },
+        "params": {
+          "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
+        }
+      }
+    },
+    "UpdateReportScheduleRequestBody": {
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
+        },
+        "cron": {
+          "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
+        },
+        "timeout": {
+          "$ref": "#/definitions/ReportScheduleRequestBodyTimeoutProperty"
+        },
+        "params": {
+          "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
+        }
+      }
+    },
+    "ReportScheduleRequestBodyNameProperty": {
+      "type": "string",
+      "description": "The name of the schedule",
+      "example": "Qui Officia"
+    },
+    "ReportScheduleRequestBodyTimeoutProperty": {
+      "type": "integer",
+      "description": "How long, in seconds, the system should wait before it decides the schedule should run\n                          again even if the last run has not completed",
+      "example": 3600
+    },
+    "ReportScheduleRequestBodyParamsProperty": {
+      "type": "object",
+      "description": "A set of key/value pairs that match report parameter names and values, if the report for this\n                        schedule has any and you would like to schedule it with specific values",
+      "example": {
+        "foo": "bar"
+      }
+    },
+    "ReportScheduleRequestBodyCronProperty": {
+      "type": "object",
+      "description": "CronLine attributes to determine your scheduled runtime. ",
+      "properties": {
+        "freq": {
+          "enum": [
+            "every_15_minutes",
+            "every_30_minutes",
+            "hourly",
+            "daily",
+            "weekly",
+            "monthly"
+          ],
+          "description": "How often this schedule repeats",
+          "example": "hourly"
+        },
+        "day_of_month": {
+          "enum": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+            31
+          ],
+          "description": "The day of the month this schedule runs on",
+          "example": 15
+        },
+        "day_of_week": {
+          "enum": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6
+          ],
+          "description": "The day of the week this schedule runs on (Sunday to Saturday)",
+          "example": 5
+        },
+        "hour": {
+          "enum": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23
+          ],
+          "description": "The hour of the day this schedule runs at (12am to 11pm)",
+          "example": 8
+        },
+        "minute": {
+          "enum": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+            31,
+            32,
+            33,
+            34,
+            35,
+            36,
+            37,
+            38,
+            39,
+            40,
+            41,
+            42,
+            43,
+            44,
+            45,
+            46,
+            47,
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+            56,
+            57,
+            58,
+            59
+          ],
+          "description": "The minute of the hour this schedules runs at",
+          "example": 0
+        },
+        "time_zone": {
+          "enum": [
+            "International Date Line West",
+            "Midway Island",
+            "American Samoa",
+            "Hawaii",
+            "Alaska",
+            "Pacific Time (US & Canada)",
+            "Tijuana",
+            "Mountain Time (US & Canada)",
+            "Arizona",
+            "Chihuahua",
+            "Mazatlan",
+            "Central Time (US & Canada)",
+            "Saskatchewan",
+            "Guadalajara",
+            "Mexico City",
+            "Monterrey",
+            "Central America",
+            "Eastern Time (US & Canada)",
+            "Indiana (East)",
+            "Bogota",
+            "Lima",
+            "Quito",
+            "Atlantic Time (Canada)",
+            "Caracas",
+            "La Paz",
+            "Santiago",
+            "Newfoundland",
+            "Brasilia",
+            "Buenos Aires",
+            "Montevideo",
+            "Georgetown",
+            "Puerto Rico",
+            "Greenland",
+            "Mid-Atlantic",
+            "Azores",
+            "Cape Verde Is.",
+            "Dublin",
+            "Edinburgh",
+            "Lisbon",
+            "London",
+            "Casablanca",
+            "Monrovia",
+            "UTC",
+            "Belgrade",
+            "Bratislava",
+            "Budapest",
+            "Ljubljana",
+            "Prague",
+            "Sarajevo",
+            "Skopje",
+            "Warsaw",
+            "Zagreb",
+            "Brussels",
+            "Copenhagen",
+            "Madrid",
+            "Paris",
+            "Amsterdam",
+            "Berlin",
+            "Bern",
+            "Zurich",
+            "Rome",
+            "Stockholm",
+            "Vienna",
+            "West Central Africa",
+            "Bucharest",
+            "Cairo",
+            "Helsinki",
+            "Kyiv",
+            "Riga",
+            "Sofia",
+            "Tallinn",
+            "Vilnius",
+            "Athens",
+            "Istanbul",
+            "Minsk",
+            "Jerusalem",
+            "Harare",
+            "Pretoria",
+            "Kaliningrad",
+            "Moscow",
+            "St. Petersburg",
+            "Volgograd",
+            "Samara",
+            "Kuwait",
+            "Riyadh",
+            "Nairobi",
+            "Baghdad",
+            "Tehran",
+            "Abu Dhabi",
+            "Muscat",
+            "Baku",
+            "Tbilisi",
+            "Yerevan",
+            "Kabul",
+            "Ekaterinburg",
+            "Islamabad",
+            "Karachi",
+            "Tashkent",
+            "Chennai",
+            "Kolkata",
+            "Mumbai",
+            "New Delhi",
+            "Kathmandu",
+            "Astana",
+            "Dhaka",
+            "Sri Jayawardenepura",
+            "Almaty",
+            "Novosibirsk",
+            "Rangoon",
+            "Bangkok",
+            "Hanoi",
+            "Jakarta",
+            "Krasnoyarsk",
+            "Beijing",
+            "Chongqing",
+            "Hong Kong",
+            "Urumqi",
+            "Kuala Lumpur",
+            "Singapore",
+            "Taipei",
+            "Perth",
+            "Irkutsk",
+            "Ulaanbaatar",
+            "Seoul",
+            "Osaka",
+            "Sapporo",
+            "Tokyo",
+            "Yakutsk",
+            "Darwin",
+            "Adelaide",
+            "Canberra",
+            "Melbourne",
+            "Sydney",
+            "Brisbane",
+            "Hobart",
+            "Vladivostok",
+            "Guam",
+            "Port Moresby",
+            "Magadan",
+            "Srednekolymsk",
+            "Solomon Is.",
+            "New Caledonia",
+            "Fiji",
+            "Kamchatka",
+            "Marshall Is.",
+            "Auckland",
+            "Wellington",
+            "Nuku'alofa",
+            "Tokelau Is.",
+            "Chatham Is.",
+            "Samoa"
+          ],
+          "description": "The name of the time zone in which to evaluate the scheduled time to run",
+          "example": "Pacific Time (US & Canada)"
+        }
+      }
+    },
+    "CreateorUpdateReportSubscriptionRequestBody": {
+      "type": "object",
+      "properties": {
+        "csv_attachments": {
+          "type": "boolean",
+          "description": "Whether or not to include Csv Attachments for subscribers to the scheduled run",
+          "example": true
+        },
+        "pdf_attachments": {
+          "type": "boolean",
+          "description": "Whether or not to include Pdf Attachments for subscribers to the scheduled run",
+          "example": true
+        },
+        "data_previews": {
+          "type": "boolean",
+          "description": "Whether or not to include Data Previews for subscribers to the scheduled run",
+          "example": true
+        },
+        "data_tables": {
+          "type": "boolean",
+          "description": "Whether or not to include Data Tables for subscribers to the scheduled run",
+          "example": true
+        },
+        "report_links": {
+          "type": "boolean",
+          "description": "Whether or not to include Report Links for subscribers to the scheduled run",
+          "example": true
+        }
+      }
+    },
+    "CreateSpaceMembershipRequestBody": {
+      "required": [
+        "membership"
+      ],
+      "type": "object",
+      "properties": {
+        "membership": {
+          "required": [
+            "member_type",
+            "member_token"
+          ],
+          "type": "object",
+          "description": "The attributes of the new member being added to the space",
+          "properties": {
+            "member_type": {
+              "type": "string",
+              "description": "The type of member, either `\"User\"` or `\"UserGroup\"`",
+              "example": "User"
+            },
+            "member_token": {
+              "type": "string",
+              "description": "The token of the member being added",
+              "example": "2bd8236f8ae4"
+            }
+          }
+        }
+      }
+    },
+    "CreateOrUpdateSpaceRequestBody": {
+      "required": [
+        "space"
+      ],
+      "type": "object",
+      "properties": {
+        "space": {
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "description": "The parameters of the new or updated space",
+          "properties": {
+            "description": {
+              "type": "string",
+              "description": "Description of the `space`"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the `space`"
+            }
+          }
+        }
+      }
+    },
+    "UpdateDataSourceRequestBody": {
+      "required": [
+        "data_source"
+      ],
+      "type": "object",
+      "properties": {
+        "data_source": {
+          "type": "object",
+          "description": "The parameters of the data source to update",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the `data source`",
+              "example": "Redshift Database"
+            },
+            "description": {
+              "type": "string",
+              "description": "Description of the `data source`",
+              "example": "Marketing data"
+            },
+            "password": {
+              "type": "string",
+              "description": "Password for the `data source`",
+              "example": "redshift_db_pw"
+            },
+            "custom_attributes": {
+              "type": "object",
+              "description": "For Oracle Autonomous Database connected via bridge, pass the connection string as a custom attribute",
+              "properties": {
+                "connection_string": {
+                  "type": "string"
+                }
+              }
+            },
+            "certificate": {
+              "type": "file"
+            },
+            "key": {
+              "type": "file"
+            },
+            "wallet": {
+              "type": "file"
+            }
+          }
+        }
+      }
+    },
+    "VizViewVegas": {
+      "required": [
+        "format",
+        "encoding",
+        "chartType"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "format": {
+          "type": "object"
+        },
+        "encoding": {
+          "type": "object"
+        },
+        "chartType": {
+          "type": "string",
+          "example": "bigValue"
+        }
+      }
+    },
+    "VizView": {
+      "required": [
+        "selectedChart",
+        "bar",
+        "bigNumber",
+        "line",
+        "linePlusBar",
+        "scatter",
+        "pie",
+        "area",
+        "pivotTable"
+      ],
+      "properties": {
+        "selectedChart": {
+          "type": "string"
+        },
+        "chartIcon": {
+          "type": "string"
+        },
+        "chartTitle": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "object"
+        },
+        "bigNumber": {
+          "type": "object"
+        },
+        "line": {
+          "type": "object"
+        },
+        "linePlusBar": {
+          "type": "object"
+        },
+        "scatter": {
+          "type": "object"
+        },
+        "pie": {
+          "type": "object"
+        },
+        "area": {
+          "type": "object"
+        },
+        "pivotTable": {
+          "type": "object"
+        }
+      }
+    },
+    "Link": {
+      "required": [
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "templated": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "Avatar": {
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "DataSourceCustomAttributes": {
+      "properties": {
+        "standard_sql": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ReportRunParameters": {},
+    "ReportFilterOptions": {},
+    "Pagination": {
+      "required": [
+        "first_page",
+        "last_page",
+        "total_pages",
+        "total_count"
+      ],
+      "properties": {
+        "first_page": {
+          "type": "string"
+        },
+        "last_page": {
+          "type": "string"
+        },
+        "total_pages": {
+          "type": "integer"
+        },
+        "total_count": {
+          "type": "integer"
+        }
+      }
+    },
+    "CreateUserGroupMembershipRequestBody": {
+      "required": [
+        "membership"
+      ],
+      "type": "object",
+      "properties": {
+        "membership": {
+          "description": "The parameters for the new membership",
+          "type": "object",
+          "required": [
+            "member_token"
+          ],
+          "properties": {
+            "member_token": {
+              "description": "The token of the user to become a member",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "UpdateUserGroupRequestBody": {
+      "required": [
+        "user_group"
+      ],
+      "type": "object",
+      "properties": {
+        "user_group": {
+          "description": "The parameters for the updated user group",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The new name for the user group",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "CreateUserGroupRequestBody": {
+      "required": [
+        "user_group"
+      ],
+      "type": "object",
+      "properties": {
+        "user_group": {
+          "description": "The parameters for the created user group",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The name for the new user group",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "Chart": {
+      "properties": {
+        "view": {
+          "$ref": "#/definitions/VizView"
+        },
+        "view_version": {
+          "type": "integer"
+        },
+        "view_vegas": {
+          "$ref": "#/definitions/VizViewVegas"
+        },
+        "token": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "color_palette_token": {
+          "type": "string"
+        },
+        "switch_view_token": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/ChartLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ChartEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "view",
+        "view_version",
+        "view_vegas",
+        "token",
+        "created_at",
+        "updated_at"
+      ]
+    },
+    "ChartLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "color_palette": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_viz_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "preview": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_run_viz_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "creator": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "report_viz_web",
+        "preview",
+        "report_run_viz_web",
+        "creator"
+      ]
+    },
+    "ChartEmbeds": {},
+    "QueryCharts": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/QueryChartsLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/QueryChartsEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "QueryChartsLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "QueryChartsEmbeds": {},
+    "DataSource": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "adapter": {
+          "enum": [
+            "jdbc:athena",
+            "jdbc:bigquery",
+            "jdbc:databricks",
+            "jdbc:dbtmetrics",
+            "jdbc:transform",
+            "jdbc:druid",
+            "jdbc:hive",
+            "jdbc:impala",
+            "jdbc:mysql",
+            "jdbc:oracle",
+            "jdbc:oracleadb",
+            "jdbc:postgresql",
+            "jdbc:trino",
+            "jdbc:presto",
+            "jdbc:redshift",
+            "jdbc:snowflake",
+            "jdbc:spark",
+            "jdbc:sqlserver",
+            "jdbc:treasuredata",
+            "jdbc:vertica"
+          ],
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "has_expensive_schema_updates": {
+          "type": "boolean"
+        },
+        "public": {
+          "type": "boolean"
+        },
+        "asleep": {
+          "type": "boolean"
+        },
+        "queryable": {
+          "type": "boolean"
+        },
+        "display_name": {
+          "type": "string"
+        },
+        "account_id": {
+          "type": "integer"
+        },
+        "account_username": {
+          "type": "string"
+        },
+        "organization_token": {
+          "type": "string"
+        },
+        "default": {
+          "type": "boolean"
+        },
+        "default_for_organization_id": {
+          "type": "boolean"
+        },
+        "database": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "string"
+        },
+        "ssl": {
+          "type": "boolean"
+        },
+        "username": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "vendor": {
+          "type": "string"
+        },
+        "ldap": {
+          "type": "boolean"
+        },
+        "warehouse": {
+          "type": "string"
+        },
+        "bridged": {
+          "type": "boolean"
+        },
+        "adapter_version": {
+          "type": "string"
+        },
+        "custom_attributes": {
+          "$ref": "#/definitions/DataSourceCustomAttributes"
+        },
+        "ssl_trusted_cert": {
+          "type": "string"
+        },
+        "default_access_level": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/DataSourceLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/DataSourceEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "id",
+        "name",
+        "description",
+        "token",
+        "adapter",
+        "created_at",
+        "updated_at",
+        "has_expensive_schema_updates",
+        "public",
+        "asleep",
+        "queryable",
+        "display_name",
+        "database",
+        "host",
+        "port",
+        "ssl",
+        "username",
+        "provider",
+        "vendor",
+        "ldap",
+        "warehouse",
+        "bridged",
+        "adapter_version",
+        "custom_attributes"
+      ]
+    },
+    "DataSourceLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "account": {
+          "$ref": "#/definitions/Link"
+        },
+        "permissions": {
+          "$ref": "#/definitions/Link"
+        },
+        "web": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_home": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "account",
+        "web",
+        "web_home"
+      ]
+    },
+    "DataSourceEmbeds": {},
+    "DataSourceSchemaUpdate": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "content_length": {
+          "type": "string"
+        },
+        "number_of_schemas": {
+          "type": "string"
+        },
+        "number_of_tables": {
+          "type": "string"
+        },
+        "last_succesful_refresh_at": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/DataSourceSchemaUpdateLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/DataSourceSchemaUpdateEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "id",
+        "token",
+        "state",
+        "content_length",
+        "number_of_schemas",
+        "number_of_tables"
+      ]
+    },
+    "DataSourceSchemaUpdateLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "DataSourceSchemaUpdateEmbeds": {},
+    "DataSources": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/DataSourcesLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/DataSourcesEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "DataSourcesLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "DataSourcesEmbeds": {},
+    "Definition": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "data_source_id": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "last_successful_sync_at": {
+          "type": "string"
+        },
+        "github_link": {
+          "type": "string"
+        },
+        "last_saved_at": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/DefinitionLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/DefinitionEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "id",
+        "token",
+        "name",
+        "description",
+        "source",
+        "data_source_id",
+        "created_at",
+        "updated_at",
+        "last_successful_sync_at",
+        "last_saved_at"
+      ]
+    },
+    "DefinitionLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "last_run": {
+          "$ref": "#/definitions/Link"
+        },
+        "last_successful_github_sync": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_edit": {
+          "$ref": "#/definitions/Link"
+        },
+        "creator": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "last_run",
+        "last_successful_github_sync",
+        "web_edit",
+        "creator"
+      ]
+    },
+    "DefinitionEmbeds": {},
+    "Definitions": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/DefinitionsLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/DefinitionsEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "DefinitionsLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "DefinitionsEmbeds": {},
+    "BadRequest": {
+      "required": [
+        "id",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "bad_request"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "Forbidden": {
+      "required": [
+        "id",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "forbidden"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "InternalServerError": {
+      "required": [
+        "id",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "internal_server_error"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "NotFound": {
+      "required": [
+        "id",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "not_found"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "ParamMissing": {
+      "required": [
+        "id",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "param_missing"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "PayloadTooLarge": {
+      "required": [
+        "id",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "payload_too_large"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "RateLimited": {
+      "required": [
+        "id",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "rate_limited"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "ServiceUnavailable": {
+      "required": [
+        "id",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "service_unavailable"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "Unauthorized": {
+      "required": [
+        "id",
+        "message"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": [
+            "unauthorized"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "FormField": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "options": {
+          "type": "string"
+        },
+        "options_error": {
+          "type": "string"
+        },
+        "source_size": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/FormFieldLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/FormFieldEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "name",
+        "options",
+        "options_error",
+        "source_size"
+      ]
+    },
+    "FormFieldLinks": {},
+    "FormFieldEmbeds": {},
+    "Invite": {
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "inviter_id": {
+          "type": "string"
+        },
+        "invitee_id": {
+          "type": "string"
+        },
+        "organization_id": {
+          "type": "string"
+        },
+        "limited": {
+          "type": "string"
+        },
+        "sent_at": {
+          "type": "string"
+        },
+        "resent_at": {
+          "type": "string"
+        },
+        "clicked_at": {
+          "type": "string"
+        },
+        "accepted_at": {
+          "type": "string"
+        },
+        "expires_at": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/InviteLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/InviteEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "email",
+        "message",
+        "inviter_id",
+        "invitee_id",
+        "organization_id",
+        "limited",
+        "expires_at",
+        "created_at"
+      ]
+    },
+    "InviteLinks": {
+      "properties": {
+        "inviter": {
+          "$ref": "#/definitions/Link"
+        },
+        "invitee": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_self_resend": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "inviter",
+        "web_self_resend"
+      ]
+    },
+    "InviteEmbeds": {},
+    "Membership": {
+      "properties": {
+        "admin": {
+          "type": "boolean"
+        },
+        "invited": {
+          "type": "boolean"
+        },
+        "state": {
+          "type": "string"
+        },
+        "member_username": {
+          "type": "string"
+        },
+        "member_token": {
+          "type": "string"
+        },
+        "activated_at": {
+          "type": "string"
+        },
+        "managed_by_scim": {
+          "type": "boolean"
+        },
+        "_links": {
+          "$ref": "#/definitions/MembershipLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/MembershipEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "admin",
+        "state",
+        "member_username",
+        "member_token",
+        "activated_at"
+      ]
+    },
+    "MembershipLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_self": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_self_unban": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_self_approve": {
+          "$ref": "#/definitions/Link"
+        },
+        "organization": {
+          "$ref": "#/definitions/Link"
+        },
+        "user": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_self_download_profile": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_self_confirm_destroy": {
+          "$ref": "#/definitions/Link"
+        },
+        "groups": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "web_self",
+        "organization",
+        "groups"
+      ]
+    },
+    "MembershipEmbeds": {},
+    "Memberships": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/MembershipsLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/MembershipsEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "MembershipsLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "MembershipsEmbeds": {},
+    "Query": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "raw_query": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "last_run_id": {
+          "type": "string"
+        },
+        "data_source_id": {
+          "type": "string"
+        },
+        "explorations_count": {
+          "type": "string"
+        },
+        "report_imports_count": {
+          "type": "string"
+        },
+        "mapping_id": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/QueryLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/QueryEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "id",
+        "token",
+        "created_at",
+        "updated_at",
+        "name",
+        "last_run_id",
+        "data_source_id",
+        "explorations_count",
+        "report_imports_count"
+      ]
+    },
+    "QueryLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "report": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_runs": {
+          "$ref": "#/definitions/Link"
+        },
+        "charts": {
+          "$ref": "#/definitions/Link"
+        },
+        "new_chart": {
+          "$ref": "#/definitions/Link"
+        },
+        "new_query_table": {
+          "$ref": "#/definitions/Link"
+        },
+        "query_tables": {
+          "$ref": "#/definitions/Link"
+        },
+        "query_runs": {
+          "$ref": "#/definitions/Link"
+        },
+        "creator": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "report",
+        "report_runs",
+        "query_runs",
+        "creator"
+      ]
+    },
+    "QueryEmbeds": {},
+    "QueryRun": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "raw_source": {
+          "type": "string"
+        },
+        "statement_annotation": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "completed_at": {
+          "type": "string"
+        },
+        "data_source_id": {
+          "type": "string"
+        },
+        "limit": {
+          "type": "string"
+        },
+        "query_token": {
+          "type": "string"
+        },
+        "query_name": {
+          "type": "string"
+        },
+        "query_created_at": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        },
+        "rendered_source": {
+          "type": "string"
+        },
+        "max_result_bytes": {
+          "type": "string"
+        },
+        "help_url": {
+          "type": "string"
+        },
+        "error_code": {
+          "type": "string"
+        },
+        "error_type": {
+          "type": "string"
+        },
+        "error_message": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/QueryRunLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/QueryRunEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "id",
+        "token",
+        "state",
+        "created_at",
+        "completed_at",
+        "data_source_id",
+        "limit",
+        "query_token",
+        "query_name",
+        "query_created_at",
+        "parameters",
+        "max_result_bytes"
+      ]
+    },
+    "QueryRunLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "query": {
+          "$ref": "#/definitions/Link"
+        },
+        "view": {
+          "$ref": "#/definitions/Link"
+        },
+        "result": {
+          "$ref": "#/definitions/Link"
+        },
+        "result_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "query_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_run": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_run_web": {
+          "$ref": "#/definitions/Link"
+        },
+        "executed_by": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "query",
+        "result",
+        "result_web",
+        "query_web",
+        "report_run",
+        "report_run_web",
+        "executed_by"
+      ]
+    },
+    "QueryRunEmbeds": {},
+    "QueryRuns": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/QueryRunsLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/QueryRunsEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "QueryRunsLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "QueryRunsEmbeds": {},
+    "ReportFilter": {
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "report_id": {
+          "type": "integer"
+        },
+        "token": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "row_order": {
+          "type": "integer"
+        },
+        "formula": {
+          "type": "string"
+        },
+        "data_type": {
+          "type": "string"
+        },
+        "formula_type": {
+          "type": "string"
+        },
+        "hide_select_all": {
+          "type": "string"
+        },
+        "filter_type": {
+          "enum": [
+            "SINGLE",
+            "MULTI",
+            "RANGE"
+          ],
+          "type": "string"
+        },
+        "control_type": {
+          "enum": [
+            "LIST",
+            "DROPDOWN",
+            "RANGE"
+          ],
+          "type": "string"
+        },
+        "variable_type": {
+          "enum": [
+            "CONTINUOUS",
+            "DISCRETE"
+          ],
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/definitions/ReportFilterOptions"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportFilterLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportFilterEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "id",
+        "report_id",
+        "token",
+        "name",
+        "row_order",
+        "formula",
+        "data_type",
+        "formula_type",
+        "hide_select_all",
+        "filter_type",
+        "control_type",
+        "variable_type",
+        "options",
+        "created_at",
+        "updated_at"
+      ]
+    },
+    "ReportFilterLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "report": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "report"
+      ]
+    },
+    "ReportFilterEmbeds": {},
+    "ReportFilters": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportFiltersLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportFiltersEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "ReportFiltersLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "ReportFiltersEmbeds": {},
+    "ReportQueries": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportQueriesLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportQueriesEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "ReportQueriesLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "ReportQueriesEmbeds": {},
+    "Report": {
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "published_at": {
+          "type": "string"
+        },
+        "edited_at": {
+          "type": "string"
+        },
+        "theme_id": {
+          "type": "integer"
+        },
+        "color_mappings": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "last_successful_sync_at": {
+          "type": "string"
+        },
+        "last_saved_at": {
+          "type": "string"
+        },
+        "archived": {
+          "type": "boolean"
+        },
+        "space_token": {
+          "type": "string"
+        },
+        "account_id": {
+          "type": "integer"
+        },
+        "account_username": {
+          "type": "string"
+        },
+        "public": {
+          "type": "boolean"
+        },
+        "full_width": {
+          "type": "boolean"
+        },
+        "manual_run_disabled": {
+          "type": "boolean"
+        },
+        "run_privately": {
+          "type": "boolean"
+        },
+        "drilldowns_enabled": {
+          "type": "boolean"
+        },
+        "layout": {
+          "type": "string"
+        },
+        "is_embedded": {
+          "type": "boolean"
+        },
+        "is_signed": {
+          "type": "boolean"
+        },
+        "shared": {
+          "type": "boolean"
+        },
+        "expected_runtime": {
+          "type": "number"
+        },
+        "last_successfully_run_at": {
+          "type": "string"
+        },
+        "last_run_at": {
+          "type": "string"
+        },
+        "web_preview_image": {
+          "type": "string"
+        },
+        "last_successful_run_token": {
+          "type": "string"
+        },
+        "flamingo_signature": {
+          "type": "string"
+        },
+        "github_link": {
+          "type": "string"
+        },
+        "query_count": {
+          "type": "string"
+        },
+        "max_query_count": {
+          "type": "string"
+        },
+        "chart_count": {
+          "type": "string"
+        },
+        "runs_count": {
+          "type": "string"
+        },
+        "schedules_count": {
+          "type": "string"
+        },
+        "query_preview": {
+          "type": "string"
+        },
+        "view_count": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "token",
+        "id",
+        "name",
+        "created_at",
+        "updated_at",
+        "published_at",
+        "edited_at",
+        "type",
+        "last_saved_at",
+        "archived",
+        "account_id",
+        "account_username",
+        "public",
+        "manual_run_disabled",
+        "run_privately",
+        "drilldowns_enabled",
+        "expected_runtime",
+        "last_successfully_run_at",
+        "last_run_at",
+        "last_successful_run_token",
+        "query_count",
+        "max_query_count",
+        "runs_count",
+        "query_preview",
+        "view_count"
+      ]
+    },
+    "ReportLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "web": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_edit": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_external_url": {
+          "$ref": "#/definitions/Link"
+        },
+        "csv_export": {
+          "$ref": "#/definitions/Link"
+        },
+        "share": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_report_runs": {
+          "$ref": "#/definitions/Link"
+        },
+        "account": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_run": {
+          "$ref": "#/definitions/Link"
+        },
+        "star": {
+          "$ref": "#/definitions/Link"
+        },
+        "space": {
+          "$ref": "#/definitions/Link"
+        },
+        "space_links": {
+          "$ref": "#/definitions/Link"
+        },
+        "queries": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_runs": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_pins": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_filters": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_schedules": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_subscriptions": {
+          "$ref": "#/definitions/Link"
+        },
+        "python_visualizations": {
+          "$ref": "#/definitions/Link"
+        },
+        "embed_key": {
+          "$ref": "#/definitions/Link"
+        },
+        "last_run": {
+          "$ref": "#/definitions/Link"
+        },
+        "last_successful_run": {
+          "$ref": "#/definitions/Link"
+        },
+        "python_notebook": {
+          "$ref": "#/definitions/Link"
+        },
+        "perspective_email_subscription_memberships": {
+          "$ref": "#/definitions/Link"
+        },
+        "validate_email_subscriber": {
+          "$ref": "#/definitions/Link"
+        },
+        "creator": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_theme": {
+          "$ref": "#/definitions/Link"
+        },
+        "last_successful_github_sync": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_index_web": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "web",
+        "account",
+        "report_run",
+        "queries",
+        "report_runs",
+        "report_pins",
+        "last_run",
+        "last_successful_run"
+      ]
+    },
+    "ReportEmbeds": {},
+    "ReportRun": {
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "pending",
+            "enqueued",
+            "cancelled",
+            "failed",
+            "succeeded",
+            "completed",
+            "running_notebook"
+          ],
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/definitions/ReportRunParameters"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "completed_at": {
+          "type": "string"
+        },
+        "purge_started_at": {
+          "type": "string"
+        },
+        "purge_completed_at": {
+          "type": "string"
+        },
+        "python_state": {
+          "enum": [
+            "none",
+            "pending",
+            "failed",
+            "submitted",
+            "succeeded"
+          ],
+          "type": "string"
+        },
+        "form_fields": {
+          "type": "array"
+        },
+        "flamingo_signature": {
+          "type": "string"
+        },
+        "flamingo_host": {
+          "type": "string"
+        },
+        "is_latest_report_run": {
+          "type": "string"
+        },
+        "is_latest_successful_report_run": {
+          "type": "string"
+        },
+        "report_has_failures_since_last_success": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportRunLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportRunEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "token",
+        "state",
+        "created_at",
+        "updated_at",
+        "completed_at",
+        "purge_started_at",
+        "purge_completed_at",
+        "flamingo_signature",
+        "flamingo_host",
+        "is_latest_report_run",
+        "is_latest_successful_report_run",
+        "report_has_failures_since_last_success"
+      ]
+    },
+    "ReportRunLinks": {
+      "properties": {
+        "latest_successful_report_run_api_url": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "content": {
+          "$ref": "#/definitions/Link"
+        },
+        "preview": {
+          "$ref": "#/definitions/Link"
+        },
+        "account": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_schedule": {
+          "$ref": "#/definitions/Link"
+        },
+        "executed_by": {
+          "$ref": "#/definitions/Link"
+        },
+        "share": {
+          "$ref": "#/definitions/Link"
+        },
+        "embed": {
+          "$ref": "#/definitions/Link"
+        },
+        "report": {
+          "$ref": "#/definitions/Link"
+        },
+        "clone": {
+          "$ref": "#/definitions/Link"
+        },
+        "query_runs": {
+          "$ref": "#/definitions/Link"
+        },
+        "python_cell_runs": {
+          "$ref": "#/definitions/Link"
+        },
+        "pdf_export": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_clone": {
+          "$ref": "#/definitions/Link"
+        },
+        "web_external_url": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "account",
+        "executed_by",
+        "report",
+        "query_runs"
+      ]
+    },
+    "ReportRunEmbeds": {},
+    "ReportRuns": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportRunsLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportRunsEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "ReportRunsLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "ReportRunsEmbeds": {},
+    "Reports": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportsLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportsEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "ReportsLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "ReportsEmbeds": {},
+    "ReportSchedule": {
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "retry_state": {
+          "type": "string"
+        },
+        "retry_count": {
+          "type": "string"
+        },
+        "retry_delay": {
+          "type": "string"
+        },
+        "timeout": {
+          "type": "string"
+        },
+        "last_run_at": {
+          "type": "string"
+        },
+        "last_succeeded_at": {
+          "type": "string"
+        },
+        "last_scheduled_run": {
+          "type": "string"
+        },
+        "next_scheduled_run": {
+          "type": "string"
+        },
+        "subscribed": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportScheduleLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportScheduleEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "token",
+        "parameters",
+        "created_at",
+        "updated_at",
+        "retry_state",
+        "retry_count",
+        "retry_delay",
+        "timeout",
+        "last_run_at",
+        "last_succeeded_at",
+        "last_scheduled_run",
+        "next_scheduled_run",
+        "subscribed"
+      ]
+    },
+    "ReportScheduleLinks": {
+      "properties": {
+        "account": {
+          "$ref": "#/definitions/Link"
+        },
+        "creator": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "report": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_runs": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_subscriptions": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "account",
+        "creator",
+        "self",
+        "report",
+        "report_runs",
+        "report_subscriptions"
+      ]
+    },
+    "ReportScheduleEmbeds": {},
+    "ReportSchedules": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportSchedulesLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportSchedulesEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "ReportSchedulesLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "ReportSchedulesEmbeds": {},
+    "ReportSubscription": {
+      "properties": {
+        "data_previews_enabled": {
+          "type": "boolean"
+        },
+        "data_tables_enabled": {
+          "type": "boolean"
+        },
+        "csv_attachments_enabled": {
+          "type": "boolean"
+        },
+        "pdf_attachments_enabled": {
+          "type": "boolean"
+        },
+        "report_links_enabled": {
+          "type": "boolean"
+        },
+        "email_subscriber_count": {
+          "type": "integer"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportSubscriptionLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportSubscriptionEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "data_previews_enabled",
+        "data_tables_enabled",
+        "csv_attachments_enabled",
+        "pdf_attachments_enabled",
+        "report_links_enabled",
+        "email_subscriber_count"
+      ]
+    },
+    "ReportSubscriptionLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "report_schedule": {
+          "$ref": "#/definitions/Link"
+        },
+        "email_subscription_memberships": {
+          "$ref": "#/definitions/Link"
+        },
+        "slack_subscription_memberships": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "report_schedule",
+        "email_subscription_memberships",
+        "slack_subscription_memberships"
+      ]
+    },
+    "ReportSubscriptionEmbeds": {},
+    "ReportSubscriptions": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/ReportSubscriptionsLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/ReportSubscriptionsEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "ReportSubscriptionsLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "ReportSubscriptionsEmbeds": {},
+    "SpaceMemberships": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/SpaceMembershipsLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/SpaceMembershipsEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "SpaceMembershipsLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "SpaceMembershipsEmbeds": {},
+    "SpaceMembership": {
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "member_token": {
+          "type": "string"
+        },
+        "member_type": {
+          "type": "string"
+        },
+        "member_id": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/SpaceMembershipLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/SpaceMembershipEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "token",
+        "member_token",
+        "member_type",
+        "member_id"
+      ]
+    },
+    "SpaceMembershipLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "member": {
+          "$ref": "#/definitions/Link"
+        },
+        "creator": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "member",
+        "creator"
+      ]
+    },
+    "SpaceMembershipEmbeds": {},
+    "Space": {
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "space_type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "restricted": {
+          "type": "boolean"
+        },
+        "free_default": {
+          "type": "string"
+        },
+        "viewable?": {
+          "type": "string"
+        },
+        "viewed?": {
+          "type": "string"
+        },
+        "default_access_level": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/SpaceLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/SpaceEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "token",
+        "id",
+        "space_type",
+        "name",
+        "description",
+        "state",
+        "restricted",
+        "free_default",
+        "viewable?"
+      ]
+    },
+    "SpaceLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "detail": {
+          "$ref": "#/definitions/Link"
+        },
+        "space_report_pins": {
+          "$ref": "#/definitions/Link"
+        },
+        "web": {
+          "$ref": "#/definitions/Link"
+        },
+        "reports": {
+          "$ref": "#/definitions/Link"
+        },
+        "creator": {
+          "$ref": "#/definitions/Link"
+        },
+        "user_space_membership": {
+          "$ref": "#/definitions/Link"
+        },
+        "space_memberships": {
+          "$ref": "#/definitions/Link"
+        },
+        "preview_space_memberships": {
+          "$ref": "#/definitions/Link"
+        },
+        "search_space_permissions": {
+          "$ref": "#/definitions/Link"
+        },
+        "viewed": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "detail",
+        "reports",
+        "creator",
+        "search_space_permissions"
+      ]
+    },
+    "SpaceEmbeds": {},
+    "Spaces": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/SpacesLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/SpacesEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "SpacesLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "SpacesEmbeds": {},
+    "UserGroupMembership": {
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "member_token": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/UserGroupMembershipLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/UserGroupMembershipEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "token",
+        "member_token"
+      ]
+    },
+    "UserGroupMembershipLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "creator": {
+          "$ref": "#/definitions/Link"
+        },
+        "member": {
+          "$ref": "#/definitions/Link"
+        },
+        "user_group": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "creator",
+        "member",
+        "user_group"
+      ]
+    },
+    "UserGroupMembershipEmbeds": {},
+    "UserGroupMemberships": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/UserGroupMembershipsLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/UserGroupMembershipsEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "UserGroupMembershipsLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "UserGroupMembershipsEmbeds": {},
+    "UserGroup": {
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "group_type": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "member_count": {
+          "type": "string"
+        },
+        "spaces_count": {
+          "type": "string"
+        },
+        "data_sources_count": {
+          "type": "string"
+        },
+        "managed": {
+          "type": "string"
+        },
+        "_links": {
+          "$ref": "#/definitions/UserGroupLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/UserGroupEmbeds"
+        }
+      },
+      "required": [
+        "_links",
+        "token",
+        "group_type",
+        "name",
+        "description",
+        "state",
+        "member_count",
+        "spaces_count",
+        "data_sources_count",
+        "managed"
+      ]
+    },
+    "UserGroupLinks": {
+      "properties": {
+        "self": {
+          "$ref": "#/definitions/Link"
+        },
+        "web": {
+          "$ref": "#/definitions/Link"
+        },
+        "creator": {
+          "$ref": "#/definitions/Link"
+        },
+        "group_memberships": {
+          "$ref": "#/definitions/Link"
+        },
+        "membership_by_id": {
+          "$ref": "#/definitions/Link"
+        },
+        "memberships_preview": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self",
+        "web",
+        "creator",
+        "group_memberships",
+        "membership_by_id",
+        "memberships_preview"
+      ]
+    },
+    "UserGroupEmbeds": {},
+    "UserGroups": {
+      "properties": {
+        "pagination": {
+          "$ref": "#/definitions/Pagination"
+        },
+        "_links": {
+          "$ref": "#/definitions/UserGroupsLinks"
+        },
+        "_embedded": {
+          "$ref": "#/definitions/UserGroupsEmbeds"
+        }
+      },
+      "required": [
+        "_links"
+      ]
+    },
+    "UserGroupsLinks": {
+      "properties": {
+        "next_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "prev_page": {
+          "$ref": "#/definitions/Link"
+        },
+        "self": {
+          "$ref": "#/definitions/Link"
+        }
+      },
+      "required": [
+        "self"
+      ]
+    },
+    "UserGroupsEmbeds": {}
+  }
+}

--- a/swagger.json
+++ b/swagger.json
@@ -4395,9 +4395,6 @@
         "cron"
       ],
       "properties": {
-        "name": {
-          "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
-        },
         "cron": {
           "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
         },
@@ -4411,9 +4408,6 @@
     },
     "UpdateReportScheduleRequestBody": {
       "properties": {
-        "name": {
-          "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
-        },
         "cron": {
           "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
         },
@@ -4424,11 +4418,6 @@
           "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
         }
       }
-    },
-    "ReportScheduleRequestBodyNameProperty": {
-      "type": "string",
-      "description": "The name of the schedule",
-      "example": "Qui Officia"
     },
     "ReportScheduleRequestBodyTimeoutProperty": {
       "type": "integer",
@@ -6823,9 +6812,6 @@
     "ReportSchedule": {
       "properties": {
         "token": {
-          "type": "string"
-        },
-        "name": {
           "type": "string"
         },
         "parameters": {

--- a/swagger.json
+++ b/swagger.json
@@ -5253,6 +5253,9 @@
         "default": {
           "type": "boolean"
         },
+        "default_for_organization_id": {
+          "type": "boolean"
+        },
         "database": {
           "type": "string"
         },

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3046,6 +3046,8 @@ definitions:
     required:
     - cron
     properties:
+      name:
+        "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
       cron:
         "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
       timeout:
@@ -3054,12 +3056,18 @@ definitions:
         "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
   UpdateReportScheduleRequestBody:
     properties:
+      name:
+        "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
       cron:
         "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
       timeout:
         "$ref": "#/definitions/ReportScheduleRequestBodyTimeoutProperty"
       params:
         "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
+  ReportScheduleRequestBodyNameProperty:
+    type: string
+    description: The name of the schedule
+    example: Qui Officia
   ReportScheduleRequestBodyTimeoutProperty:
     type: integer
     description: |-
@@ -3729,8 +3737,6 @@ definitions:
       organization_token:
         type: string
       default:
-        type: boolean
-      default_for_organization_id:
         type: boolean
       database:
         type: string
@@ -4815,6 +4821,8 @@ definitions:
   ReportsEmbeds: {}
   ReportSchedule:
     properties:
+      name:
+        type: string
       token:
         type: string
       parameters:
@@ -4847,6 +4855,7 @@ definitions:
         "$ref": "#/definitions/ReportScheduleEmbeds"
     required:
     - _links
+    - name
     - token
     - parameters
     - created_at

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3738,6 +3738,8 @@ definitions:
         type: string
       default:
         type: boolean
+      default_for_organization_id:
+        type: boolean
       database:
         type: string
       host:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3046,8 +3046,6 @@ definitions:
     required:
     - cron
     properties:
-      name:
-        "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
       cron:
         "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
       timeout:
@@ -3056,18 +3054,12 @@ definitions:
         "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
   UpdateReportScheduleRequestBody:
     properties:
-      name:
-        "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
       cron:
         "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
       timeout:
         "$ref": "#/definitions/ReportScheduleRequestBodyTimeoutProperty"
       params:
         "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
-  ReportScheduleRequestBodyNameProperty:
-    type: string
-    description: The name of the schedule
-    example: Qui Officia
   ReportScheduleRequestBodyTimeoutProperty:
     type: integer
     description: |-
@@ -4824,8 +4816,6 @@ definitions:
   ReportSchedule:
     properties:
       token:
-        type: string
-      name:
         type: string
       parameters:
         type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3066,8 +3066,8 @@ definitions:
         "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
   ReportScheduleRequestBodyNameProperty:
     type: string
-    description: The name of the schedule
-    example: Qui Officia
+    description: 'The name of the schedule'
+    example: 'Qui Officia'
   ReportScheduleRequestBodyTimeoutProperty:
     type: integer
     description: |-

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3046,6 +3046,8 @@ definitions:
     required:
     - cron
     properties:
+      name:
+        "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
       cron:
         "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
       timeout:
@@ -3054,12 +3056,18 @@ definitions:
         "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
   UpdateReportScheduleRequestBody:
     properties:
+      name:
+        "$ref": "#/definitions/ReportScheduleRequestBodyNameProperty"
       cron:
         "$ref": "#/definitions/ReportScheduleRequestBodyCronProperty"
       timeout:
         "$ref": "#/definitions/ReportScheduleRequestBodyTimeoutProperty"
       params:
         "$ref": "#/definitions/ReportScheduleRequestBodyParamsProperty"
+  ReportScheduleRequestBodyNameProperty:
+    type: string
+    description: The name of the schedule
+    example: Qui Officia
   ReportScheduleRequestBodyTimeoutProperty:
     type: integer
     description: |-
@@ -4816,6 +4824,8 @@ definitions:
   ReportSchedule:
     properties:
       token:
+        type: string
+      name:
         type: string
       parameters:
         type: string


### PR DESCRIPTION
# What

Add name to API definition for createReportSchedule and updateReportSchedule now that ReportSchedule update and created endpoints set the name attribute when provided in the request payload.

# Why
The _name_ field has been added to the report_schedules table and is passed in body  when creating or updating a report schedule via the API.
req'd as part of https://github.com/mode/issues/issues/12784
